### PR TITLE
fix: engine yellow-LED NaN check and comment cleanups

### DIFF
--- a/solar_router/engine_1dimmer.yaml
+++ b/solar_router/engine_1dimmer.yaml
@@ -5,8 +5,8 @@ packages:
   - !include engine_common.yaml
 
 switch:
-  # Define is router is active or not
-  # When switch is ON, pooling timer will trigger every seconds
+  # Defines if the router is active or not
+  # When switch is ON, polling timer will trigger every second
   - platform: template
     name: "Activate Solar Routing"
     optimistic: true
@@ -21,7 +21,7 @@ switch:
       then:
         - light.turn_off: green_led
         - number.to_min: router_level
-        - lambda: |- 
+        - lambda: |-
             id(consumption).publish_state(NAN);
             id(power_meter_activated) = 0;
             id(real_power).publish_state(NAN);
@@ -130,11 +130,11 @@ script:
   - id: energy_regulation
     mode: single
     then:
-      # Define the reouter level based on power measured and grid exchange target
-      # The value of regulator is a precentage and is then limited to the range 0 100
+      # Define the router level based on power measured and grid exchange target
+      # The value of regulator is a percentage and is then limited to the range 0 100
       - lambda: |-
           if (isnan(id(real_power).state) or id(safety_limit)){
-            // If we can have information about grid exchange or if safety_limit is active, do not divert any energy
+            // If grid-exchange info is unavailable (NaN) or the safety limit is active, do not divert any energy
             id(router_level).publish_state(0);
             return;
           }

--- a/solar_router/engine_common.yaml
+++ b/solar_router/engine_common.yaml
@@ -24,16 +24,16 @@ sensor:
               script.execute: energy_regulation
 
 substitutions:
-  # By default led are pin control is not inverted
+  # By default LEDs are pin-controlled and not inverted
   green_led_inverted: "False"
   yellow_led_inverted: "False"
   # By default regulators are hidden
   hide_regulators: "True"
-  # By default leds are hidden
+  # By default LEDs are hidden
   hide_leds: "True"
 
 # Component managing time.
-# If activate switch is ON, yellow led update is performed every secondes
+# If the activate switch is ON, yellow LED update is performed every second
 time:
   - platform: sntp
     on_time:
@@ -47,9 +47,9 @@ time:
                 - light.turn_off: yellow_led
                 - if:
                     condition:
-                      lambda: return id(real_power).state == NAN;
+                      lambda: return isnan(id(real_power).state);
                     then:
-                      # When NAN is returns, it means that an error occurs. Yellow LED blink fast
+                      # When real_power is NaN, it means an error occurred. Yellow LED blinks fast
                       - light.turn_on:
                           id: yellow_led
                           effect: fast


### PR DESCRIPTION
## Summary

Two small engine fixes:

1. **NaN check** — in `solar_router/engine_common.yaml`, the yellow-LED error indicator compared `id(real_power).state == NAN`. Comparing to NAN is always `false` in C++, so the fast-blink error indicator never triggered. Replaced with `isnan(id(real_power).state)` (same pattern already used in `engine_1dimmer.yaml`'s `energy_regulation`).

2. **Comment cleanups** — fixed typos in `engine_common.yaml` and `engine_1dimmer.yaml` ("leds"→"LEDs", "every secondes"→"every second", "reouter"→"router", "precentage"→"percentage", trailing whitespace in a lambda block).

## Test

- `esphome config` passes on a harness config combining `common`, `engine_1dimmer`, `power_meter_shelly_em3`, `regulator_triac`, `dimmer_safety` packages.