### PR TITLE
feat: add dimmer board safety package (heatsink NTC + overcurrent + health alarms)

### DIFF
--- a/docs/en/dimmer_safety.md
+++ b/docs/en/dimmer_safety.md
@@ -1,0 +1,53 @@
+# Dimmer board safety (RobotDyn AC Dimmer 40 A "with current sensor")
+
+This package adds local safety for the **RobotDyn AC Dimmer 40 A "with current sensor"** (premium variant: heatsink NTC + 5 V fan + built-in CT current sensor).
+
+It provides three layers:
+
+1. **Local heatsink temperature limiter** — works without WiFi or Home Assistant:
+   - heatsink >= `heatsink_stop_temperature` → `safety_limit = True` (engine drops to 0 %)
+   - heatsink <= `heatsink_restart_temperature` → `safety_limit = False`
+   - temperature sensor failure (NaN) → `safety_limit = True` (fail-safe)
+
+2. **Overcurrent cutout** — load current >= `overcurrent_current` → `safety_limit = True`
+   - cleared once current falls back under `overcurrent_restart_current`
+
+3. **Health alarms** (informational, no power cut):
+   - *Triac Stuck ON*: current flowing while the regulator is closed (shorted triac)
+   - *Boiler Not Powered*: regulator open but no current (dead triac / gate)
+   - *Current Sensor Failure*: CT output not readable
+
+To use this package, add the following lines to your configuration file:
+
+```yaml linenums="1"
+packages:
+  safety:
+    url: https://github.com/hacf-fr/Solar-Router-for-ESPHome/
+    file: solar_router/dimmer_safety.yaml
+    vars:
+      dimmer_temp_pin: GPIO34
+      dimmer_current_pin: GPIO35
+      red_led_pin: GPIO21
+```
+
+!!! note "Only ONE safety limiter package"
+    This package owns the shared `safety_limit` global (same as the temperature
+    limiter packages). Include only one safety limiter package in a configuration.
+
+## Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `dimmer_temp_pin` | `GPIO34` | Heatsink NTC input (ESP32 ADC1, input-only pin 32–39) |
+| `dimmer_current_pin` | `GPIO35` | CT current sensor input (ESP32 ADC1) |
+| `red_led_pin` | `GPIO21` | Safety LED output |
+| `heatsink_stop_temperature` | `80` | Cutout temperature (°C) |
+| `heatsink_restart_temperature` | `60` | Restart temperature (°C) |
+| `overcurrent_current` | `12.0` | Overcurrent threshold (A RMS) |
+| `overcurrent_restart_current` | `8.0` | Overcurrent restart threshold (A RMS) |
+| `current_calibration_factor` | `1.0` | CT calibration (A per V on the CUR pin), tune on the bench |
+
+The NTC calibration (`ntc_reference_*`, `ntc_b_coefficient`, `ntc_configuration`) can be adjusted to match the board's divider — see the bench procedure.
+
+!!! warning "Analog inputs"
+    `dimmer_temp_pin` and `dimmer_current_pin` must be ESP32 ADC1 pins (input-only pins 32–39).

--- a/docs/fr/dimmer_safety.md
+++ b/docs/fr/dimmer_safety.md
@@ -1,0 +1,54 @@
+# Sécurité de la carte gradateur (RobotDyn AC Dimmer 40 A "avec capteur de courant")
+
+Ce package ajoute une sécurité locale pour le **RobotDyn AC Dimmer 40 A "avec capteur de courant"** (variante premium : NTC dissipateur + ventilateur 5 V + capteur de courant CT intégré).
+
+Il fournit trois niveaux de protection :
+
+1. **Limiteur de température du dissipateur** — fonctionne sans WiFi ni Home Assistant :
+   - dissipateur >= `heatsink_stop_temperature` → `safety_limit = True` (le moteur passe à 0 %)
+   - dissipateur <= `heatsink_restart_temperature` → `safety_limit = False`
+   - panne du capteur de température (NaN) → `safety_limit = True` (sécurité intrinsèque)
+
+2. **Coupure surintensité** — courant de charge >= `overcurrent_current` → `safety_limit = True`
+   - débloqué une fois le courant repassé sous `overcurrent_restart_current`
+
+3. **Alarmes de santé** (informatives, pas de coupure) :
+   - *Triac Stuck ON* : courant circulant alors que le régulateur est fermé (triac en court-circuit)
+   - *Boiler Not Powered* : régulateur ouvert mais aucun courant (triac mort / gâchette)
+   - *Current Sensor Failure* : sortie CT illisible
+
+Pour utiliser ce package, ajoutez les lignes suivantes à votre fichier de configuration :
+
+```yaml linenums="1"
+packages:
+  safety:
+    url: https://github.com/hacf-fr/Solar-Router-for-ESPHome/
+    file: solar_router/dimmer_safety.yaml
+    vars:
+      dimmer_temp_pin: GPIO34
+      dimmer_current_pin: GPIO35
+      red_led_pin: GPIO21
+```
+
+!!! note "Un SEUL package de limitation de sécurité"
+    Ce package possède la variable globale partagée `safety_limit` (comme les
+    packages *temperature limiter*). N'incluez qu'un seul package de limitation
+    de sécurité dans une configuration.
+
+## Variables
+
+| Variable | Défaut | Description |
+|---|---|---|
+| `dimmer_temp_pin` | `GPIO34` | Entrée NTC du dissipateur (ADC1 ESP32, broches input-only 32–39) |
+| `dimmer_current_pin` | `GPIO35` | Entrée du capteur de courant CT (ADC1 ESP32) |
+| `red_led_pin` | `GPIO21` | Sortie LED de sécurité |
+| `heatsink_stop_temperature` | `80` | Température de coupure (°C) |
+| `heatsink_restart_temperature` | `60` | Température de redémarrage (°C) |
+| `overcurrent_current` | `12.0` | Seuil de surintensité (A RMS) |
+| `overcurrent_restart_current` | `8.0` | Seuil de redémarrage surintensité (A RMS) |
+| `current_calibration_factor` | `1.0` | Calibration du CT (A par V sur la broche CUR), à régler sur banc |
+
+La calibration NTC (`ntc_reference_*`, `ntc_b_coefficient`, `ntc_configuration`) peut être ajustée pour correspondre au diviseur de la carte — voir la procédure de banc.
+
+!!! warning "Entrées analogiques"
+    `dimmer_temp_pin` et `dimmer_current_pin` doivent être des broches ADC1 de l'ESP32 (broches input-only 32–39).

--- a/esp32-dimmer-safety.yaml
+++ b/esp32-dimmer-safety.yaml
@@ -1,0 +1,75 @@
+# ----------------------------------------------------------------------------------------------------
+# ESPHome configuration - This part depends on your hardware target
+# ----------------------------------------------------------------------------------------------------
+# Example: ESP32-based solar router with the RobotDyn AC Dimmer 40 A "with current sensor"
+# (heatsink NTC + built-in CT) and the local board safety package.
+# ----------------------------------------------------------------------------------------------------
+
+esphome:
+  name: dimmer-safety
+  friendly_name: Dimmer Safety
+  min_version: 2025.5.0
+
+esp32:
+  board: esp32dev
+  framework:
+    type: esp-idf
+
+# Enable logging
+logger:
+  baud_rate: 115200
+  level: INFO
+  logs:
+    component: ERROR
+    light: ERROR
+
+# Enable Home Assistant API
+api:
+  encryption:
+    key: !secret api_encryption_key
+
+# Enable over-the-air updates
+ota:
+  - platform: esphome
+    password: !secret solar_router_ota_password
+
+# WiFi connection
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+  reboot_timeout: 24h
+
+# Activate web interface
+web_server:
+  port: 80
+
+# Define watchdog time (it should be greater than timeout)
+http_request:
+  watchdog_timeout: 12s
+
+# ----------------------------------------------------------------------------------------------------
+# Customisation
+# ----------------------------------------------------------------------------------------------------
+packages:
+  solar_router:
+    url: https://github.com/hacf-fr/Solar-Router-for-ESPHome/
+    ref: main
+    refresh: 1d
+    files:
+      - path: solar_router/common.yaml
+      - path: solar_router/power_meter_home_assistant.yaml
+        vars:
+          power_meter_activated_at_start: "1"
+      - path: solar_router/regulator_triac.yaml
+        vars:
+          regulator_gate_pin: GPIO17
+          regulator_zero_crossing_pin: GPIO23
+      - path: solar_router/engine_1dimmer.yaml
+        vars:
+          green_led_pin: GPIO18
+          yellow_led_pin: GPIO19
+      - path: solar_router/dimmer_safety.yaml
+        vars:
+          dimmer_temp_pin: GPIO34
+          dimmer_current_pin: GPIO35
+          red_led_pin: GPIO21

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,8 @@ nav:
               - Overview: temperature_limiter.md
               - Home Assistant: temperature_limiter_home_assistant.md
               - DS18B20: temperature_limiter_DS18B20.md
+      - Dimmer board safety:
+              - RobotDyn 40 A with current sensor: dimmer_safety.md
       - Scheduler:
               - Overview: scheduler.md
               - Forced Run: scheduler_forced_run.md
@@ -115,6 +117,7 @@ plugins:
                             Solar Router / Diverter: Routeur solaire
                             Standalone: Routeur autonome
                             Temperature Limiter: Limiteur de température
+                            Dimmer board safety: Sécurité carte gradateur
                             Theorical: Théorique
                             With proxy: Router utilisant un proxy
                             With Solar Optimizer integration: Avec l'utilisation de l'intégration Solar Optimizer

--- a/solar_router/dimmer_safety.yaml
+++ b/solar_router/dimmer_safety.yaml
@@ -1,0 +1,194 @@
+# ----------------------------------------------------------------------------------------------------
+# Board safety package for the RobotDyn AC Dimmer 40A "with current sensor" (premium variant,
+# heatsink NTC + 5V fan + built-in CT current sensor).
+#
+# Provides:
+#   - Local heatsink temperature limiter (works without WiFi / Home Assistant):
+#       heatsink >= stop temperature   -> safety_limit = True  (engine drops to 0 %)
+#       heatsink <= restart temperature-> safety_limit = False
+#       Sensor failure (NaN)           -> safety_limit = True  (fail-safe)
+#   - Overcurrent cutout: load current >= threshold -> safety_limit = True
+#       (cleared once current falls back under the restart threshold)
+#   - Health alarms (no power cut, for information):
+#       "Triac Stuck ON"       : current flowing while the regulator is closed
+#       "Boiler Not Powered"   : regulator open but no current (dead triac / gate)
+#       "Current Sensor Failure": CT output not readable
+#
+# NOTE: this package owns the shared `safety_limit` global (same as the temperature
+# limiter packages). Include ONLY ONE safety limiter package in a configuration.
+# ----------------------------------------------------------------------------------------------------
+substitutions:
+  # Analog inputs (ESP32 ADC1, input-only pins 32-39)
+  dimmer_temp_pin: "GPIO34"
+  dimmer_current_pin: "GPIO35"
+  red_led_pin: "GPIO21"
+  red_led_inverted: "False"
+  # Temperature limiter thresholds (°C)
+  heatsink_stop_temperature: "80"
+  heatsink_restart_temperature: "60"
+  # Current thresholds (A RMS)
+  overcurrent_current: "12.0"
+  overcurrent_restart_current: "8.0"
+  # Health alarms
+  stuck_current_threshold: "1.0"
+  stuck_opening_threshold: "1.0"
+  no_load_current_threshold: "0.5"
+  no_load_opening_threshold: "50.0"
+  # Current sensor calibration (A per volt on the CUR pin), tune on the bench
+  current_calibration_factor: "1.0"
+  # Heatsink NTC calibration - adjust to match the board's divider, see bench procedure
+  ntc_reference_voltage: "3.3"
+  ntc_reference_resistance: "10000Ω"
+  ntc_reference_temperature: "25°C"
+  ntc_b_coefficient: "3350"
+  ntc_series_resistor: "10000Ω"
+  ntc_configuration: "DOWNSTREAM"
+
+esphome:
+  on_boot:
+    priority: -1000.0
+    then:
+      - script.execute: dimmer_safety_check
+
+globals:
+  - id: heatsink_overheat
+    type: bool
+    initial_value: "false"
+  - id: load_overcurrent
+    type: bool
+    initial_value: "false"
+
+sensor:
+  # Raw heatsink NTC voltage
+  - platform: adc
+    id: heatsink_voltage
+    pin: ${dimmer_temp_pin}
+    attenuation: 12db
+    update_interval: 1s
+    internal: "True"
+
+  # NTC resistance computed from the board divider
+  - platform: resistance
+    id: heatsink_resistance
+    sensor: heatsink_voltage
+    reference_voltage: ${ntc_reference_voltage}
+    configuration: ${ntc_configuration}
+    resistor: ${ntc_series_resistor}
+    internal: "True"
+
+  # Heatsink temperature
+  - platform: ntc
+    id: heatsink_temperature
+    name: "Dimmer Heatsink Temperature"
+    device_class: temperature
+    unit_of_measurement: "°C"
+    sensor: heatsink_resistance
+    calibration:
+      b_constant: ${ntc_b_coefficient}
+      reference_resistance: ${ntc_reference_resistance}
+      reference_temperature: ${ntc_reference_temperature}
+    filters:
+      - median:
+          window_size: 5
+    on_value:
+      - script.execute: dimmer_safety_check
+
+  # Raw CT output voltage
+  - platform: adc
+    id: load_current_voltage
+    pin: ${dimmer_current_pin}
+    attenuation: 12db
+    update_interval: 1s
+    internal: "True"
+
+  # Load current (RMS) flowing through the dimmer.
+  # Note: ESPHome's ct_clamp publishes the AC RMS voltage of the source as "A"
+  # (1 V/A); the board trimmer sets the CT gain and `current_calibration_factor`
+  # rescales the result (tune on the bench).
+  - platform: ct_clamp
+    id: load_current
+    name: "Dimmer Load Current"
+    device_class: current
+    unit_of_measurement: "A"
+    sensor: load_current_voltage
+    filters:
+      - multiply: ${current_calibration_factor}
+    sample_duration: 200ms
+    update_interval: 1s
+    on_value:
+      - script.execute: dimmer_safety_check
+
+binary_sensor:
+  # Any board safety cutout active (heatsink overheat or overcurrent)
+  - platform: template
+    name: "Dimmer Safety Active"
+    device_class: problem
+    lambda: |-
+      return id(heatsink_overheat) || id(load_overcurrent);
+
+  # Current is flowing although the regulator is closed: triac shorted
+  - platform: template
+    name: "Triac Stuck ON"
+    device_class: problem
+    lambda: |-
+      return !isnan(id(load_current).state) && !isnan(id(regulator_opening).state)
+             && id(regulator_opening).state < ${stuck_opening_threshold}
+             && id(load_current).state > ${stuck_current_threshold};
+
+  # Regulator is open but no current flows: dead triac or gate failure
+  - platform: template
+    name: "Boiler Not Powered"
+    device_class: problem
+    lambda: |-
+      return !isnan(id(load_current).state) && !isnan(id(regulator_opening).state)
+             && id(regulator_opening).state > ${no_load_opening_threshold}
+             && id(load_current).state < ${no_load_current_threshold};
+
+  # CT output not readable
+  - platform: template
+    name: "Current Sensor Failure"
+    device_class: problem
+    lambda: |-
+      return isnan(id(load_current).state);
+
+script:
+  # Heatsink overheat + overcurrent state machines, update shared safety_limit
+  - id: dimmer_safety_check
+    mode: single
+    then:
+      - lambda: |-
+          // Heatsink temperature limiter (fail-safe on sensor loss)
+          if (isnan(id(heatsink_temperature).state)) {
+            id(heatsink_overheat) = true;
+          } else if (id(heatsink_overheat)) {
+            if (id(heatsink_temperature).state <= ${heatsink_restart_temperature}) {
+              id(heatsink_overheat) = false;
+            }
+          } else {
+            if (id(heatsink_temperature).state >= ${heatsink_stop_temperature}) {
+              id(heatsink_overheat) = true;
+            }
+          }
+          // Overcurrent cutout (NaN current never trips, only alarms)
+          if (id(load_overcurrent)) {
+            if (id(load_current).state <= ${overcurrent_restart_current}) {
+              id(load_overcurrent) = false;
+            }
+          } else {
+            if (id(load_current).state >= ${overcurrent_current}) {
+              id(load_overcurrent) = true;
+            }
+          }
+          id(safety_limit) = id(heatsink_overheat) || id(load_overcurrent);
+          if (id(safety_limit)) {
+            id(red_led).turn_on();
+          } else {
+            id(red_led).turn_off();
+          }
+
+output:
+  - id: red_led
+    platform: gpio
+    pin:
+      number: ${red_led_pin}
+      inverted: ${red_led_inverted}


### PR DESCRIPTION
## Summary

Adds a new optional package `solar_router/dimmer_safety.yaml` providing local safety for the RobotDyn AC Dimmer 40 A "with current sensor" (premium variant: heatsink NTC, 5 V fan, built-in CT):

- **Heatsink temperature limiter** (works without WiFi / Home Assistant): hysteresis on `safety_limit`, fail-safe on sensor failure (NaN)
- **Overcurrent cutout**: load current >= threshold sets `safety_limit`, restart below lower threshold
- **Health alarms** (no power cut): Triac Stuck ON / Boiler Not Powered / Current Sensor Failure

The package owns the shared `safety_limit` global (same as the temperature limiter packages) — only one safety limiter package per configuration.

## Files
- `solar_router/dimmer_safety.yaml` — the package
- `esp32-dimmer-safety.yaml` — full usage example (triac + engine_1dimmer + safety)
- `docs/en/dimmer_safety.md`, `docs/fr/dimmer_safety.md`, mkdocs nav entries

## Validation
- `esphome config` valid (esp32dev, with substitutions)
- `tools/check_build_coverage.sh` OK
- `tools/check_documentation_coverage.sh` OK
- `mkdocs build --strict` OK