### PR TITLE
feat: EV priority Home Assistant blueprint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,328 @@
+# AGENTS.md - AI Development Guidelines for Solar Router for ESPHome
+
+## Project Overview
+
+**Solar Router for ESPHome** is a DIY project providing specialized hardware and software for optimizing solar energy utilization. It performs real-time monitoring and intelligent surplus energy management to channel excess solar energy to designated loads like water heaters or frost protection systems. The project integrates seamlessly with Home Assistant via ESPHome firmware.
+
+## Role & Responsibilities
+
+You are an AI assistant helping with the development of ESPHome firmware configurations for this project. Your primary responsibilities include:
+
+- Maintaining and extending ESPHome YAML configurations
+- Ensuring consistency across modular package system
+- Validating YAML syntax and ESPHome compatibility
+- Assisting with documentation updates
+- Helping with testing and validation scripts
+
+## Repository Structure
+
+```
+Solar-Router-for-ESPHome/
+├── docs/                    # Documentation (English & French)
+│   ├── en/                 # English documentation
+│   └── fr/                 # French documentation
+├── solar_router/           # Reusable ESPHome packages (core development area)
+│   ├── common.yaml         # Common components (restart switch, uptime sensor)
+│   ├── engine_*.yaml       # Engine configurations (1dimmer, 1switch, etc.)
+│   ├── engine_common.yaml  # Common engine functionality
+│   ├── power_meter_*.yaml  # Power meter integrations
+│   ├── regulator_*.yaml    # Regulator types (triac, relay)
+│   ├── energy_counter_*.yaml # Energy counting methods
+│   ├── temperature_limiter_*.yaml # Temperature safety
+│   └── scheduler_*.yaml    # Scheduling functionality
+├── blueprints/            # Home Assistant blueprints (YAML)
+├── *.yaml                 # Complete device configurations
+├── tools/                 # Development and validation scripts
+├── site/                  # Generated documentation site
+├── .esphome/              # ESPHome build cache
+└── mkdocs.yml             # Documentation configuration
+```
+
+## Development Guidelines
+
+### 1. ESPHome YAML Standards
+
+**ALWAYS:**
+- Use consistent indentation (2 spaces)
+- Follow existing naming conventions (snake_case for IDs, spaces in display names)
+- Include comments for each major section
+- Use substitutions for configurable parameters
+- Maintain backward compatibility when possible
+- Test configurations with `esphome validate` before committing
+
+**NEVER:**
+- Hardcode IP addresses or credentials (use secrets.yaml or variables)
+- Remove existing functionality without discussion
+- Break the modular package system
+- Use tabs for indentation
+- Commit API keys or passwords
+
+### 2. Package Architecture Rules
+
+The project uses a **modular package system** where:
+
+- **`solar_router/`** contains reusable component packages
+- **Root YAML files** are complete device configurations that reference packages
+- **Packages must be self-contained** and declarative
+- **Dependencies flow upward**: common → specialized packages → device configs
+
+**Package Types:**
+- **Common**: `common.yaml` - Base components for all devices
+- **Power Meters**: Measure grid energy exchange (Fronius, HA API, Proxy, JSY-MK-194T, Shelly EM, Shelly EM3 Pro)
+- **Engines**: Control logic for energy diversion (progressive or ON/OFF)
+- **Regulators**: Physical control (Triac, SSR, Mechanical Relay)
+- **Energy Counters**: Track diverted energy
+- **Temperature Limiters**: Safety mechanisms
+- **Schedulers**: Time-based automation
+
+### 3. Configuration Patterns
+
+**Required Structure for Device Configs:**
+```yaml
+# Hardware-specific configuration
+esphome:
+  name: device-name
+  friendly_name: Display Name
+  # Actual pin varies by target: see esp32-standalone.yaml (2026.1.0),
+  # esp32-JSY-MK-194T.yaml (2025.9.0), etc. Update per feature use.
+  min_version: 2026.1.0
+
+# Hardware platform (esp32, esp8266, etc.)
+# ...
+
+# Standard components
+logger:
+api:
+  encryption:
+    key: !secret api_encryption_key
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password
+
+# Package inclusion
+packages:
+  solar_router:
+    url: https://github.com/hacf-fr/Solar-Router-for-ESPHome/
+    ref: main
+    files:
+      - path: solar_router/common.yaml
+      - path: solar_router/power_meter_*.yaml
+        vars:
+          parameter: value
+      - path: solar_router/regulator_*.yaml
+        vars:
+          pin: GPIOxx
+```
+
+### 4. Variable and Substitution Conventions
+
+**Global Variables:**
+- Use `globals:` for runtime state
+- Use `substitutions:` for compile-time configuration
+- Prefix internal IDs with component name (e.g., `regulator_opening`, `real_power`)
+
+**Common Substitutions:**
+- `green_led_pin`, `yellow_led_pin` - LED GPIO pins (values are board-specific; see the target `.yaml` header)
+- `regulator_gate_pin`, `regulator_zero_crossing_pin` - Regulator control pins
+- `power_meter_ip_address` - Network addresses
+- `hide_regulators`, `hide_leds` - Visibility toggles
+
+### 5. Home Assistant Integration
+
+**Sensor Standards:**
+- Use appropriate `device_class` (power, energy, temperature, etc.)
+- Set `unit_of_measurement` appropriately
+- Use `internal: true` for debugging sensors
+- Follow HA naming conventions for entity names
+
+**Entity Types:**
+- **Switches**: For ON/OFF controls (Activate Solar Routing, Restart)
+- **Numbers**: For configurable parameters (Router Level, Reactivity, etc.)
+- **Sensors**: For readings (Real Power, Consumption, Uptime)
+- **Lights**: For LED indicators (Yellow Led, Green Led)
+
+### 6. Documentation Requirements
+
+**Every module in `solar_router/` MUST have:**
+- Corresponding English documentation in `docs/en/`
+- French translation in `docs/fr/`
+- Diagram images in `docs/images/` where applicable
+
+**Documentation Check:**
+```bash
+./tools/check_documentation_coverage.sh
+```
+
+### 7. Testing and Validation
+
+**Before Committing:**
+1. Validate YAML syntax: `esphome validate <config>.yaml`
+2. Check documentation coverage: `./tools/check_documentation_coverage.sh`
+3. Verify build compatibility: `./tools/compile_all_local_yaml.sh`
+
+**Validation Tools:**
+- Use `esphome config` / `esphome compile` for configuration validation
+- Use `esphome run` for testing (with hardware or simulator)
+- HTTP server simulator available in `tools/http_server_simulator.py`
+
+### 8. Version Control Standards
+
+**Commit Messages:**
+- Follow [Conventional Commits](https://www.conventionalcommits.org/)
+- Use prefixes: `feat:`, `fix:`, `doc:`, `refactor:`, `build:`, `chore:`
+- Reference issues with `#number` when applicable
+
+**Changelog:**
+- Auto-generated using `git-cliff` (configured in `cliff.toml`)
+- Update via: `./tools/update_documentation.sh`
+
+**Branching:**
+- Main branch: `main`
+- Feature branches: `feat/description` or `feature/description`
+- Releases are cut as `vX.Y.Z` tags on `main`; there is no long-lived `release/*` branch.
+
+### 9. Security Considerations
+
+**NEVER commit:**
+- API encryption keys
+- WiFi passwords
+- OTA passwords
+- IP addresses
+
+**ALWAYS use:**
+- `!secret` references for sensitive data
+- Environment variables for local testing
+- `.gitignore` for local configuration files
+
+### 10. Hardware-Specific Notes
+
+**Supported Platforms:**
+- ESP32 (primary development target)
+- ESP8266 (limited configurations)
+- ESP8285 (proxy clients)
+- WT32-ETH01 (Ethernet support)
+
+**Common Hardware Configurations:**
+- Triac-based regulators: Require zero-crossing detection
+- Relay-based regulators: Simpler ON/OFF control
+- Multiple regulator types supported in same firmware
+
+**GPIO Usage:**
+Actual pin numbers are board-specific. See the `substitutions:` block at
+the top of the relevant device YAML (e.g. `esp32-standalone.yaml`,
+`esp32-JSY-MK-194T.yaml`, `esp8266-proxy_client.yaml`) for authoritative
+values.
+
+Typical assignments (verify per board):
+- LED indicators: exposed via `green_led_pin` / `yellow_led_pin` substitutions
+- Triac gate: exposed via `regulator_gate_pin`
+- Zero-crossing: exposed via `regulator_zero_crossing_pin` (inverted; on
+  `esp32-standalone.yaml` this is GPIO23)
+- Temperature sensor: exposed via `DS18B20_pin`
+
+## Workflow Commands
+
+### Development
+```bash
+# Validate a configuration
+esphome config path/to/config.yaml
+
+# Check all local configurations
+./tools/check_build_coverage.sh
+
+# Compile all local YAML files
+./tools/compile_all_local_yaml.sh
+
+# Check documentation completeness
+./tools/check_documentation_coverage.sh
+```
+
+### Documentation
+```bash
+# Update changelog and publish docs
+./tools/update_documentation.sh
+
+# Build documentation locally
+mkdocs build
+
+# Serve documentation locally
+mkdocs serve
+```
+
+## Common Tasks
+
+### Adding a New Power Meter Integration
+1. Create `solar_router/power_meter_<name>.yaml`
+2. Include `power_meter_common.yaml` via a `packages:` block
+3. Implement the `power_meter_source` script — this is the entry point
+   the SNTP `on_time` handler in the package calls; the script must
+   publish the grid-exchange power to `id(real_power)` (and, where
+   applicable, house consumption to `id(consumption)`). See
+   `power_meter_fronius.yaml` and `power_meter_shelly_em.yaml` for
+   reference implementations.
+4. Add documentation in `docs/en/power_meter_<name>.md`
+5. Add French translation in `docs/fr/`
+6. Update `mkdocs.yml` navigation
+
+### Adding a New Engine Type
+1. Create `solar_router/engine_<type>.yaml`
+2. Include `engine_common.yaml` via a `packages:` block
+3. Implement regulation logic in scripts
+4. Add corresponding documentation
+5. Ensure backward compatibility with existing regulators
+
+### Adding a New Regulator Type
+1. Create `solar_router/regulator_<type>.yaml`
+2. Define output components and control scripts
+3. Document hardware requirements
+4. Add wiring diagrams to `docs/images/`
+
+## Troubleshooting Guide
+
+### Common Issues
+- **YAML syntax errors**: Use `esphome config` with full path
+- **Missing substitutions**: Ensure all variables are defined or passed via `vars:`
+- **ESPHome version mismatch**: Update `min_version` in esphome section
+- **Network connectivity**: Check WiFi credentials in secrets.yaml
+- **API connection**: Verify encryption key and Home Assistant configuration
+
+### Debugging
+- Enable debug logging: Set `logger: level: DEBUG`
+- Use serial monitor: `esphome logs <device>.yaml`
+- Check LED indicators: Yellow LED shows WiFi status, Green LED shows routing status
+
+## Resources
+
+- **ESPHome Documentation**: https://esphome.io/
+- **Home Assistant ESPHome Integration**: https://www.home-assistant.io/integrations/esphome/
+- **Project Documentation**: https://hacf-fr.github.io/Solar-Router-for-ESPHome/
+- **Issue Tracker**: https://github.com/hacf-fr/Solar-Router-for-ESPHome/issues
+
+## AI-Specific Instructions
+
+When assisting with this project:
+
+1. **Always read the relevant documentation** before suggesting changes
+2. **Test your suggestions** with validation tools when possible
+3. **Maintain consistency** with existing patterns and conventions
+4. **Ask for clarification** if requirements are ambiguous
+5. **Provide complete examples** when showing how to implement features
+6. **Reference existing code** when proposing new functionality
+7. **Respect the modular architecture** - don't suggest changes that would break the package system
+
+**For YAML modifications:**
+- Always show the complete section being modified
+- Include proper indentation
+- Maintain comment formatting
+- Use existing variable names when possible
+
+**For documentation:**
+- Follow existing markdown style
+- Include code examples with proper YAML formatting
+- Reference related components and dependencies
+- Maintain both English and French versions
+
+---
+
+*Project: Solar Router for ESPHome*
+*Maintainer: hacf-fr*

--- a/blueprints/priority_to_ev.yaml
+++ b/blueprints/priority_to_ev.yaml
@@ -1,0 +1,262 @@
+blueprint:
+  name: "Solar Router EV Control"
+  description: >
+    Gives an electric vehicle charging priority over the Solar Router's
+    diversion load (water heater, etc.) when enough solar surplus is
+    available to charge the EV.
+
+    An EV charger typically requires at least ~1.4 kW to start drawing
+    power. If the sum of the power being diverted by the Solar Router
+    plus the power currently exported to the grid is greater than this
+    minimum, then enough surplus exists to run the EV charger — some of
+    which the router is capturing instead of leaving for the EV. In
+    that case this automation turns OFF the Solar Router so the full
+    surplus is redirected to the EV charger.
+
+    Once the EV is full (either the SOC reaches the configured full
+    threshold, or the surplus starts flowing back to the grid because
+    the EV has stopped drawing), the Solar Router is turned back ON to
+    resume diversion. When the EV is unplugged, the router is turned ON
+    unconditionally.
+
+    Anti-flicker: once the EV reports a SOC greater than or equal to
+    `ev_full_soc`, the router is no longer deactivated to give priority
+    to the EV, so a full EV never interrupts diversion.
+
+    Sign convention: this blueprint assumes the Solar Router firmware
+    default (`power_sign: "1"`), where `solar_router.real_power` is
+    positive when imported from the grid and negative when exported.
+    The available-surplus figure used internally is computed as
+    `diverted_power - real_power`, so it grows both with power the
+    router is diverting and with power flowing to the grid.
+  domain: automation
+  homeassistant:
+    min_version: 2024.8.0
+  input:
+    ev_connected:
+      name: EV Connected
+      description: "Binary sensor indicating whether the EV is plugged in."
+      selector:
+        entity:
+          domain: binary_sensor
+    diverted_power:
+      name: Diverted Power (solar_router.power_divertion)
+      description: >
+        Sensor reporting the instantaneous power (W) diverted by the
+        Solar Router to its load. Typically
+        `sensor.<device>_power_divertion`, exposed when one of the
+        `energy_counter_*.yaml` packages is included in the router
+        firmware configuration.
+      selector:
+        entity:
+          domain: sensor
+          device_class: power
+    grid_power:
+      name: Grid Power (solar_router.real_power)
+      description: >
+        Grid exchange power in watts. Positive = imported from grid,
+        negative = exported to grid (firmware default `power_sign: "1"`).
+      selector:
+        entity:
+          domain: sensor
+          device_class: power
+    solar_router:
+      name: Solar Router (solar_router.activate)
+      description: "Switch entity that enables/disables the Solar Router."
+      selector:
+        entity:
+          domain: switch
+    ev_soc:
+      name: EV State of Charge
+      description: >
+        Sensor reporting the EV battery state of charge (%). Once the
+        SOC reaches `ev_full_soc`, the router will not be deactivated to
+        make room for the EV — this prevents the router from flickering
+        off/on on a full battery. If your charger does not expose an
+        SOC sensor, point this at a sensor that always reads 0 %, or
+        raise `ev_full_soc` to 101 % to effectively disable the guard.
+      selector:
+        entity:
+          domain: sensor
+    ev_charging_threshold:
+      name: EV charging power threshold
+      description: >
+        Minimum total surplus (diverted + exported, in watts) required
+        to consider that the EV can be charged. When this threshold is
+        crossed the Solar Router is turned OFF so the surplus is
+        redirected to the EV. Set this to the EV charger's minimum
+        charging power; 1400 W is typical (single-phase EV charger
+        minimum ~1.4 kW).
+      default: 1400
+      selector:
+        number:
+          min: 0
+          max: 10000
+          step: 50
+          unit_of_measurement: "W"
+    delay_before_deactivation:
+      name: Delay Before Deactivation
+      description: "Delay in seconds before deactivating the Solar Router."
+      default: 60
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: "seconds"
+    ev_full_threshold:
+      name: EV full detection threshold
+      description: >
+        Surplus (in watts) that indicates the EV has stopped drawing
+        (battery full). When the router is OFF and the total surplus
+        stays above this threshold, the router is reactivated to
+        resume diversion. Should be smaller than the EV charging
+        threshold.
+      default: 200
+      selector:
+        number:
+          min: 0
+          max: 10000
+          step: 50
+          unit_of_measurement: "W"
+    delay_before_activation:
+      name: Delay Before Activation
+      description: "Delay in seconds before activating the Solar Router."
+      default: 60
+      selector:
+        number:
+          min: 0
+          max: 300
+          unit_of_measurement: "seconds"
+    ev_full_soc:
+      name: EV full SOC threshold
+      description: >
+        Battery state of charge (%) at or above which the EV is
+        considered full. When the SOC reaches this value the router is
+        no longer deactivated to give priority to the EV. Set to 101 %
+        to disable the anti-flicker guard.
+      default: 100
+      selector:
+        number:
+          min: 0
+          max: 101
+          step: 1
+          unit_of_measurement: "%"
+
+mode: queued
+max: 2
+
+trigger_variables:
+  diverted_entity: !input diverted_power
+  grid_entity: !input grid_power
+  ev_soc_entity: !input ev_soc
+
+variables:
+  diverted_entity: !input diverted_power
+  grid_entity: !input grid_power
+  ev_soc_entity: !input ev_soc
+  ev_charging_threshold: !input ev_charging_threshold
+  ev_full_threshold: !input ev_full_threshold
+  ev_full_soc: !input ev_full_soc
+
+trigger:
+  - platform: event
+    event_type: automation_reloaded
+  - platform: state
+    entity_id: !input ev_connected
+    to: "on"
+    for:
+      seconds: !input delay_before_deactivation
+  - platform: state
+    entity_id: !input ev_connected
+    to: "off"
+    for:
+      seconds: !input delay_before_activation
+  # Available surplus climbs above the EV charging threshold -> candidate to deactivate the router.
+  # Both diverted_power and grid_power are listed so a rising diverted value with a flat grid still re-evaluates the template.
+  - platform: numeric_state
+    entity_id:
+      - !input grid_power
+      - !input diverted_power
+    value_template: >
+      {% if has_value(diverted_entity) and has_value(grid_entity) %}
+        {{ (states(diverted_entity) | float) - (states(grid_entity) | float) }}
+      {% else %}
+        0
+      {% endif %}
+    above: !input ev_charging_threshold
+    for:
+      seconds: !input delay_before_deactivation
+  # Available surplus climbs above the EV-full threshold while router is off -> candidate to reactivate.
+  - platform: numeric_state
+    entity_id:
+      - !input grid_power
+      - !input diverted_power
+    value_template: >
+      {% if has_value(diverted_entity) and has_value(grid_entity) %}
+        {{ (states(diverted_entity) | float) - (states(grid_entity) | float) }}
+      {% else %}
+        0
+      {% endif %}
+    above: !input ev_full_threshold
+    for:
+      seconds: !input delay_before_activation
+
+action:
+  - choose:
+      # Condition 1: EV plugged in, router on, EV not yet full, and total
+      # surplus (diverted + exported) is greater than the EV charging
+      # threshold -> turn the router off so the surplus can feed the EV.
+      - conditions:
+          - condition: state
+            entity_id: !input ev_connected
+            state: "on"
+          - condition: state
+            entity_id: !input solar_router
+            state: "on"
+          - condition: template
+            value_template: >
+              {{ has_value(diverted_entity)
+                 and has_value(grid_entity)
+                 and ((states(diverted_entity) | float)
+                      - (states(grid_entity) | float))
+                     > (ev_charging_threshold | float(0)) }}
+          # Anti-flicker guard: once the EV reports full, never take the
+          # router down for it. If the SOC sensor is unavailable we
+          # default to "not full" so charging still gets priority.
+          - condition: template
+            value_template: >
+              {{ (states(ev_soc_entity) | float(0)) < (ev_full_soc | float(100)) }}
+        sequence:
+          - action: switch.turn_off
+            target:
+              entity_id: !input solar_router
+      # Condition 2: Router off, EV still plugged in, but surplus is
+      # again flowing back to the grid (EV has stopped drawing, battery
+      # full) -> reactivate the router to resume diversion.
+      - conditions:
+          - condition: state
+            entity_id: !input ev_connected
+            state: "on"
+          - condition: state
+            entity_id: !input solar_router
+            state: "off"
+          - condition: template
+            value_template: >
+              {{ has_value(diverted_entity)
+                 and has_value(grid_entity)
+                 and ((states(diverted_entity) | float)
+                      - (states(grid_entity) | float))
+                     > (ev_full_threshold | float(0)) }}
+        sequence:
+          - action: switch.turn_on
+            target:
+              entity_id: !input solar_router
+      # Condition 3: EV unplugged -> router should run normally.
+      - conditions:
+          - condition: state
+            entity_id: !input ev_connected
+            state: "off"
+        sequence:
+          - action: switch.turn_on
+            target:
+              entity_id: !input solar_router

--- a/docs/en/blueprint_priority_to_ev.md
+++ b/docs/en/blueprint_priority_to_ev.md
@@ -1,0 +1,183 @@
+# Blueprint Priority_To_EV
+
+This blueprint activates and deactivates the Solar Router so that an
+EV requiring charge gets priority whenever the household has enough
+solar surplus to run the EV charger.
+
+## Behavior
+
+The decision is driven by the total available solar surplus, computed as
+the sum of the power currently being **diverted** by the router and the
+power currently being **exported** to the grid:
+
+```
+available_surplus = diverted_power + exported_power
+                  = diverted_power - grid_power     (grid_power < 0 when exporting)
+```
+
+The blueprint follows this algorithm:
+
+```
+// EV is disconnected
+IF NOT ev_connected
+THEN activate the solar router
+
+// EV is connected, EV is not yet full, and enough surplus is available
+// to run the EV charger
+IF ev_connected
+   AND ev_soc < ev_full_soc                              // anti-flicker guard
+   AND available_surplus > ev_charging_threshold         // e.g. 1400 W
+       FOR delay_before_deactivation seconds
+THEN deactivate the solar router
+     (so the diverted portion is released and joins the exported portion,
+      giving the EV access to the full surplus)
+
+// EV battery is fully charged - the EV no longer draws power, so
+// surplus reappears in the grid export
+IF ev_connected
+   AND the solar router is deactivated
+   AND available_surplus > ev_full_threshold             // e.g. 200 W
+       FOR delay_before_activation seconds
+THEN activate the solar router.
+```
+
+Checking the *sum* (diverted + exported) rather than just the exported
+power matters when the router is not yet saturated: even at 30% diversion
+with a near-zero grid balance, the routed power alone may already be
+enough to feed the EV. This condition would be missed by an export-only
+threshold.
+
+## Sign convention
+
+This blueprint assumes the Solar Router firmware default (`power_sign: "1"`),
+where `solar_router.real_power` is **positive when energy is imported** from
+the grid and **negative when exported**. The two power thresholds
+(`ev_charging_threshold`, `ev_full_threshold`) are expressed as **positive**
+watts (the minimum required surplus magnitude), and `ev_full_soc` is a
+percentage.
+
+## A day in the life
+
+Walk through a typical sunny day to see how the blueprint reacts.
+
+**Setup used for the example**
+
+- Diversion load (water heater): 3 kW resistance
+- EV charger: dynamic — draws roughly whatever surplus is available, up to ~3.3 kW (16 A single-phase)
+- Base house consumption: ~200 W (fridge, standby, etc.)
+- Blueprint defaults:
+    - `ev_charging_threshold` = 1400 W
+    - `ev_full_threshold` = 200 W
+    - `delay_before_deactivation` = 60 s
+    - `delay_before_activation` = 60 s
+    - `ev_full_soc` = 100 %
+
+**Column legend**
+
+- **Prod.** — solar production
+- **Div.** — power currently diverted by the router (`solar_router.power_divertion`)
+- **EV** — power drawn by the EV charger
+- **Grid** — grid exchange (`solar_router.real_power`, positive = import, negative = export)
+- **Surp.** — `Div. − Grid`, the value the blueprint tests against its thresholds
+- **SOC** — EV battery state of charge (`ev_soc`)
+- **Router** — state of `solar_router.activate` before / after this moment
+
+All power values in watts.
+
+| Time  | What happens                            | Prod. | Div. | EV   | Grid  | Surp. | SOC | Router | Blueprint |
+|-------|-----------------------------------------|------:|-----:|-----:|------:|------:|----:|:------:|-----------|
+| 06:00 | Night, EV unplugged                     |     0 |    0 |    — |  +200 |  −200 |  — | ON     | idle (Cond. 3 already latched) |
+| 07:00 | User plugs the EV in                    |    50 |    0 |    0 |  +150 |  −150 | 40% | ON     | plug trigger armed with `delay_before_deactivation` |
+| 09:00 | Sun ramps up, water heater warming      |  1000 |  800 |    0 |     0 |   800 | 40% | ON     | surplus < 1400 W, EV waits |
+| 10:29 | Just under the threshold                |  1500 | 1300 |    0 |     0 |  1300 | 40% | ON     | nothing |
+| 10:30 | Surplus crosses `ev_charging_threshold` |  2000 | 1800 |    0 |     0 |  1800 | 40% | ON     | 60 s timer arms |
+| 10:31 | Timer elapsed → **Condition 1**         |  2000 | 1800 |    0 |     0 |  1800 | 40% | ON→**OFF** | router turned off (SOC < 100 %) |
+| 10:31 | EV starts drawing                       |  2000 |    0 | 1800 |     0 |     0 | 40% | OFF    | surplus fell to 0, no further trigger |
+| 13:00 | Peak sun, EV drawing max                |  3500 |    0 | 3300 |     0 |     0 | 80% | OFF    | steady state |
+| 15:00 | EV battery reaches full, stops drawing  |  3000 |    0 |    0 | −2800 |  2800 | 100%| OFF    | surplus jumps, 60 s timer arms |
+| 15:01 | Timer elapsed → **Condition 2**         |  3000 |    0 |    0 | −2800 |  2800 | 100%| OFF→**ON** | router turned back on |
+| 15:01 | Router recaptures the surplus           |  3000 | 2800 |    0 |     0 |  2800 | 100%| ON     | Cond. 1 blocked by SOC guard — see note |
+| 17:30 | Sun dropping                            |  1200 | 1000 |    0 |     0 |  1000 | 100%| ON     | surplus < 1400 W anyway, water heater keeps priority |
+| 20:00 | No sun                                  |     0 |    0 |    0 |  +200 |  −200 | 100%| ON     | idle |
+| 20:30 | User unplugs the EV                     |     0 |    0 |    — |  +200 |  −200 |  — | ON     | Cond. 3 fires, router already on (no-op) |
+
+### The two decision moments in detail
+
+**10:30 → deactivate the router (Condition 1).** The router is diverting
+1800 W to the water heater and the grid is balanced at zero — no export.
+An "export-only" rule would ignore this situation entirely. But the sum
+`Div. − Grid = 1800 − 0 = 1800 W` is above `ev_charging_threshold`
+(1400 W), the SOC is 40 % (below `ev_full_soc`), and it stays there for
+the 60 s delay. So Condition 1 fires and the router is turned off. The
+water heater releases the 1800 W, which the EV picks up (grid stays
+near zero, no wasted export).
+
+**15:00 → reactivate the router (Condition 2).** The EV finished
+charging and stops drawing. With the router still off, the full solar
+surplus now flows back to the grid: `Grid = −2800 W`. The sum
+`0 − (−2800) = 2800 W` is above `ev_full_threshold` (200 W). After 60 s,
+Condition 2 fires and the router resumes diversion.
+
+### Why doesn't Condition 1 fire again at 15:01?
+
+Right after Condition 2 turns the router back on, we're at:
+`Div. = 2800 W, Grid = 0 W, Surp. = 2800 W` — again well above 1400 W,
+which normally would send us straight into another deactivation.
+
+That doesn't happen because the SOC is now 100 % (≥ `ev_full_soc`), so
+Condition 1's anti-flicker guard blocks the transition. The router
+stays on and the water heater keeps consuming the surplus until either
+the EV is unplugged or its SOC drops below `ev_full_soc` again (e.g.
+after driving).
+
+### Known behavior
+
+- **Overnight lockout.** If the router is OFF at sunset with the EV
+  still plugged in, nothing brings it back on until the next day's
+  surplus climbs above `ev_full_threshold` and stays there for
+  `delay_before_activation`. Consider adding a manual override or a
+  time-based re-arm if that matters for your setup.
+- **Sensor drop-outs.** If either `diverted_power` or `grid_power`
+  becomes `unavailable` / `unknown`, the surplus is treated as 0 W
+  until both come back. That means no state change is triggered —
+  which is the safe default, but it also means the router is left in
+  whatever state it was in when the sensor went away.
+- **Plug / unplug debounce.** State transitions on `ev_connected` are
+  debounced with `delay_before_deactivation` and
+  `delay_before_activation` respectively. A brief connector wiggle
+  won't slam the router off then back on.
+- **SOC sensor unavailable.** If `ev_soc` reports `unavailable`, the
+  guard evaluates as "not full" — the blueprint continues to give EV
+  priority. If you don't have an SOC sensor at all, raise
+  `ev_full_soc` to 101 % to disable the guard.
+- **Cloud drops production below EV draw.** The EV keeps charging
+  (from diminished solar + a bit of grid import), the router stays
+  off, and the blueprint stays idle — surplus is now negative, so
+  neither Condition 1 nor Condition 2 can fire. The EV pulls from the
+  grid until sun returns or you intervene.
+- **Automation reloaded / Home Assistant restarted.** The
+  `automation_reloaded` event runs the `choose` block once with the
+  current state, ensuring Condition 3 (EV unplugged → router ON) is
+  re-applied if it was pending.
+
+## Installation
+
+To install this blueprint, refer to the [Home Assistant documentation](https://www.home-assistant.io/docs/automation/using_blueprints/).
+
+The URL to use is: [https://raw.githubusercontent.com/hacf-fr/Solar-Router-for-ESPHome/refs/heads/main/blueprints/priority_to_ev.yaml](https://raw.githubusercontent.com/hacf-fr/Solar-Router-for-ESPHome/refs/heads/main/blueprints/priority_to_ev.yaml)
+
+!!! note
+    `ev_connected` is a binary sensor. If your EV charger exposes a
+    string status ("EV Connected", "Charging", ...) you'll need a
+    template binary sensor.
+
+    Example for MyEnergi Zappi:
+
+    ```yaml
+    template:
+        - binary_sensor:
+            - name: "EV Connected Status"
+              unique_id: ev_connected_status
+              state: "{{ is_state('sensor.myenergi_zappi_plug_status', 'EV Connected') }}"
+              device_class: plug
+    ```

--- a/docs/en/blueprint_use_cases.md
+++ b/docs/en/blueprint_use_cases.md
@@ -1,0 +1,65 @@
+# Solar Router EV Priority - Use Cases
+
+**Focus:** Interaction between Solar Router and EV Charger when EV has priority.
+
+**Assumptions:**
+
+- Solar Router diverts surplus to a load (e.g., water heater)
+- EV Charger requires ~1400 W minimum to start charging
+- When both need power, EV has priority
+- "No surplus" = Solar Router at 0 % diversion is normal (router stays ON)
+- **Production sensor is available** and represents total solar generation
+- **EV SOC sensor is available**; `ev_full_soc` = 100 % (default)
+
+The blueprint is **stateless w.r.t. reason**: it cannot tell "cloud hid
+the sun" apart from "the EV is still charging". Both look the same to
+the automation — only the current values of `diverted_power`,
+`grid_power`, `ev_connected`, `ev_soc`, and the router switch matter.
+
+## Truth table
+
+| #   | Situation                              | EV Plugged | SOC   | Production | Grid    | Div.  | Surplus | Solar Router | Action    | Reason                                                              |
+| --- | -------------------------------------- | ---------- | ----: | ---------: | ------: | ----: | ------: | ------------ | --------- | ------------------------------------------------------------------- |
+| **Baseline: EV not plugged** ||||||||||
+| 1   | EV not plugged                         | No         |   N/A |        Any |     Any |   Any |     Any | OFF          | Turn ON   | Cond. 3 — normal operation                                          |
+| 2   | EV not plugged                         | No         |   N/A |        Any |     Any |   Any |     Any | ON           | Unchanged | Cond. 3 — already on                                                |
+| **EV plugged — not enough for EV** ||||||||||
+| 3   | EV plugged, sun too small              | Yes        |  40 % |      600 W |   −10 W | 600 W |   610 W | ON           | Unchanged | Surplus < 1400 W, Cond. 1 not met                                   |
+| **EV plugged — needs charging** ||||||||||
+| 4   | EV plugged, enough surplus             | Yes        |  40 % |     1400 W |   −10 W |   0 W |    10 W | ON           | Unchanged | Surplus 10 W < 1400 W, Cond. 1 not met (production alone is not surplus) |
+| 4b  | EV plugged, enough surplus             | Yes        |  40 % |     3000 W |     0 W |1500 W |  1500 W | ON           | Turn OFF  | Cond. 1 — surplus 1500 W > 1400 W                                   |
+| **EV actively charging** ||||||||||
+| 6   | EV plugged, EV drawing max             | Yes        |  50 % |     3400 W |   −10 W |   0 W |    10 W | OFF          | Unchanged | Cond. 2 needs surplus > 200 W                                       |
+| 7   | Cloud reduces production while OFF     | Yes        |  60 % |      600 W |  −400 W |   0 W |   400 W | OFF          | Turn ON   | Cond. 2 — surplus 400 W > 200 W. Router recaptures the exported W.  |
+| **EV full — reactivation logic (SOC = 100 %)** ||||||||||
+| 8   | High production, high export           | Yes        | 100 % |     3400 W | −1200 W |   0 W |  1200 W | OFF          | Turn ON   | Cond. 2 — surplus > 200 W                                           |
+| 9   | High production, low export            | Yes        | 100 % |     3400 W |   −10 W |   0 W |    10 W | OFF          | Unchanged | Surplus 10 W < 200 W (EV is still drawing what's left)              |
+| 10  | Low production                         | Yes        | 100 % |     1000 W |   −50 W |   0 W |    50 W | OFF          | Unchanged | Surplus 50 W < 200 W, Cond. 2 not met                               |
+| **Anti-flicker: EV at 100 %, router ON** ||||||||||
+| 11  | High surplus                           | Yes        | 100 % |     3400 W | −1200 W |2200 W |  3400 W | ON           | Unchanged | SOC guard blocks Cond. 1 — never stop diverting once EV is full     |
+| 12  | Low surplus                            | Yes        | 100 % |      600 W |  −100 W |   0 W |   100 W | ON           | Unchanged | SOC guard blocks Cond. 1 (surplus is below threshold anyway)        |
+| **Boundary cases** ||||||||||
+| 13  | Surplus exactly 1400 W                 | Yes        |  40 % |     3200 W |     0 W |1400 W |  1400 W | ON           | Unchanged | `above:` is strict inequality — needs > 1400 W                      |
+| 14  | Surplus exactly 200 W (router OFF)     | Yes        | 100 % |     3400 W |  −200 W |   0 W |   200 W | OFF          | Unchanged | `above:` is strict inequality — needs > 200 W                       |
+
+## Notes on the corrections vs the earlier draft
+
+- The old table had **row 5 and row 7** with identical inputs but
+  different actions ("Turn ON" vs "Unchanged"). Since the blueprint has
+  no way to tell "cloud" apart from "EV still charging", the outcome is
+  the same in both cases and only one row is needed. It is now row 7.
+- **Row 10** previously showed "Turn ON" at 50 W surplus, but Condition 2
+  requires *strictly* > `ev_full_threshold` (200 W). The action is
+  actually "Unchanged".
+- **Row 11** now shows a consistent set of numbers (Div = 2200 W,
+  Grid = −1200 W ⇒ Surplus = 3400 W) and the reason is spelled out —
+  the SOC guard is what blocks Condition 1, not any implicit
+  "anti-flicker" logic in earlier rows.
+- **Rows 13 and 14** clarify the `above:` semantics — the numeric-state
+  trigger fires on strict "greater than", so an exactly-at-threshold
+  reading never fires.
+
+## Related
+
+- [Blueprint reference](blueprint_priority_to_ev.md) — full behavior,
+  worked example, and edge cases.

--- a/docs/fr/blueprint_priority_to_ev.md
+++ b/docs/fr/blueprint_priority_to_ev.md
@@ -1,0 +1,15 @@
+# Blueprint Priorité au véhicule électrique
+
+!!! note
+    Cette page n'a pas encore été traduite en français. Se référer à la
+    [version anglaise](../en/blueprint_priority_to_ev.md) pour le moment.
+
+Ce blueprint active et désactive le routeur solaire pour donner la
+priorité à la charge d'un véhicule électrique dès que le surplus solaire
+disponible est suffisant pour alimenter le chargeur.
+
+## Installation
+
+Pour installer ce blueprint, se référer à la [documentation Home Assistant](https://www.home-assistant.io/docs/automation/using_blueprints/).
+
+L'URL à utiliser est : [https://raw.githubusercontent.com/hacf-fr/Solar-Router-for-ESPHome/refs/heads/main/blueprints/priority_to_ev.yaml](https://raw.githubusercontent.com/hacf-fr/Solar-Router-for-ESPHome/refs/heads/main/blueprints/priority_to_ev.yaml)

--- a/docs/fr/blueprint_use_cases.md
+++ b/docs/fr/blueprint_use_cases.md
@@ -1,0 +1,6 @@
+# Cas d'utilisation — priorité au véhicule électrique
+
+!!! note
+    Cette page n'a pas encore été traduite en français. Se référer à la
+    [version anglaise](../en/blueprint_use_cases.md) pour la table de
+    vérité complète et les commentaires associés.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -47,6 +47,8 @@ nav:
               - Overview: scheduler.md
               - Forced Run: scheduler_forced_run.md
       - Home Assistant:
+              - Blueprint Priority_to_EV: blueprint_priority_to_ev.md
+              - Blueprint use cases: blueprint_use_cases.md
               - Recorder configuration: recorder_configuration.md
               - Debug sensors: debug_sensors.md
       - About:
@@ -99,6 +101,7 @@ plugins:
                       nav_translations:
                             About: A propos
                             Alternatives: Alternatives
+                            Blueprint use cases: Cas d'utilisation
                             Contributing: Contribution
                             Disclamer: Avertissement
                             Energy Counter: Compteur d'énergie


### PR DESCRIPTION
## Summary
- Adds `blueprints/priority_to_ev.yaml`, a Home Assistant blueprint that gives the EV charger priority over the Solar Router's diversion load whenever there is enough solar surplus to run the EV, and reactivates the router once the EV is full or unplugged.
- Ships the reference doc as `docs/en/blueprint_priority_to_ev.md` (with French stub) and a corrected truth-table page `docs/en/blueprint_use_cases.md`; both wired into `mkdocs.yml`.
- Adds a top-level `AGENTS.md` describing the project's layout, package system, and conventions for AI assistants working on the repo.

## Design decisions

- **`numeric_state` triggers list both `grid_power` and `diverted_power`** in `entity_id`. Home Assistant only re-evaluates the template when a listed entity changes — the classic blueprint pitfall is to list only the grid sensor, in which case a rising diverted value with a flat grid never re-fires the trigger. Both entities are listed so every surplus change is observed.
- **Anti-flicker `ev_soc` guard.** Once `ev_soc >= ev_full_soc` (default 100 %), Condition 1 is blocked and the router is not deactivated. This is what makes the "never stop at full" behaviour actually happen in code. Users without an SOC sensor can raise `ev_full_soc` to 101 % to disable the guard.
- **`mode: queued, max: 2`** avoids the sunrise-recovery race in which both numeric-state triggers cross their thresholds simultaneously and one is dropped under `mode: single`.
- **Plug/unplug debounce.** `ev_connected` state triggers use `for: !input delay_before_deactivation` / `delay_before_activation`, so a connector wiggle can't slam the router.
- **`has_value(...)` guards** on the surplus template and Condition 1 treat sensor drop-outs as 0 W surplus rather than 0-substituted phantom surplus that could spuriously deactivate the router.
- **`homeassistant.min_version: 2024.8.0`** pinned for `action:` keys, `trigger_variables` + `!input`, and `has_value()`.

## Docs

- `docs/en/blueprint_priority_to_ev.md` — full algorithm, worked "day in the life" example, and a Known-behavior section covering overnight lockout, sensor drop-outs, plug debounce, SOC unavailability, and reload semantics.
- `docs/en/blueprint_use_cases.md` — corrected truth table (a prior draft had row 5 vs row 7 diverging on identical inputs, row 10 acting on a surplus below `ev_full_threshold`, and row 11 arithmetic inconsistent with the shown numbers).
- French stubs added under `docs/fr/`; `mkdocs.yml` nav updated for both locales.

## Test plan
- [ ] Import the blueprint into Home Assistant and confirm all inputs render.
- [ ] Walk a scripted state sequence covering every row of the truth table (particularly rows 5/7/10/11/12 and boundary rows 13/14).
- [ ] Force `diverted_power` to `unavailable` mid-run and confirm the router does not flip.
- [ ] `mkdocs serve` locally and confirm the new pages appear under both `/en/` and `/fr/` navs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)