### PR TITLE
ci: build only impacted ESPHome configs on PRs

### DIFF
--- a/.github/workflows/esphome-ci.yaml
+++ b/.github/workflows/esphome-ci.yaml
@@ -30,10 +30,11 @@ jobs:
 
       - name: 📄 Build matrix
         id: set-matrix
+        env:
+          BUILD_MATRIX_BASE: ${{ github.event.pull_request.base.sha }}
+          BUILD_MATRIX_HEAD: ${{ github.event.pull_request.head.sha }}
         run: |
           MATRIX=$(bash ./tools/build_matrix.sh \
-            "${{ github.event.pull_request.base.sha }}" \
-            "${{ github.event.pull_request.head.sha }}" \
             | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "ESPHome build matrix: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/esphome-ci.yaml
+++ b/.github/workflows/esphome-ci.yaml
@@ -1,6 +1,6 @@
 name: ESPHome Full Build CI
 
-on: [push, pull_request]
+on: [pull_request]
 
 jobs:
   # Step 0 : Test repository tooling first
@@ -31,14 +31,10 @@ jobs:
       - name: 📄 Build matrix
         id: set-matrix
         run: |
-          if [ "${{ github.event_name }}" = "push" ]; then
-            MATRIX=$(bash ./tools/build_matrix.sh --all | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          else
-            MATRIX=$(bash ./tools/build_matrix.sh \
-              "${{ github.event.pull_request.base.sha }}" \
-              "${{ github.event.pull_request.head.sha }}" \
-              | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          fi
+          MATRIX=$(bash ./tools/build_matrix.sh \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            | jq -R -s -c 'split("\n") | map(select(length > 0))')
           echo "ESPHome build matrix: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
@@ -116,7 +112,7 @@ jobs:
       - name: 🔄 Point packages at the PR head repo & ref
         env:
           HEAD_REPO_URL: ${{ github.event.pull_request.head.repo.clone_url || format('https://github.com/{0}.git', github.repository) }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
           echo "Rewriting package source in ${{ matrix.file }} → $HEAD_REPO_URL @ $HEAD_REF"
           sed -i \

--- a/.github/workflows/esphome-ci.yaml
+++ b/.github/workflows/esphome-ci.yaml
@@ -3,8 +3,22 @@ name: ESPHome Full Build CI
 on: [push, pull_request]
 
 jobs:
+  # Step 0 : Test repository tooling first
+  tools-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🧪 Install Bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: 🧪 Run tool tests
+        run: bats tests/tools
+
   # Step 1 : Determine impacted root configurations
   list-files:
+    needs: [tools-tests]
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -28,21 +42,9 @@ jobs:
           echo "ESPHome build matrix: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
-  # Step 1.5 : Test repository tooling
-  tools-tests:
-    runs-on: ubuntu-latest
-    steps:
-      - name: 📥 Checkout repository
-        uses: actions/checkout@v7
-
-      - name: 🧪 Install Bats
-        run: sudo apt-get update && sudo apt-get install -y bats
-
-      - name: 🧪 Run tool tests
-        run: bats tests/tools
-
   # Step 2 : Check Coverage
   coverage:
+    needs: [tools-tests]
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
@@ -55,6 +57,7 @@ jobs:
 
   # Step 2.5 : Check Version
   check-version:
+    needs: [tools-tests]
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository
@@ -67,6 +70,7 @@ jobs:
 
   # Step 3 : Build & Validate Documentation
   docs:
+    needs: [tools-tests]
     runs-on: ubuntu-latest
     steps:
       - name: 📥 Checkout repository

--- a/.github/workflows/esphome-ci.yaml
+++ b/.github/workflows/esphome-ci.yaml
@@ -19,7 +19,7 @@ jobs:
         run: |
           # Liste les .yaml à la racine, exclut secrets.yaml.
           # Sur une PR, ne compile que les configurations modifiées lorsque
-          # les seuls changements sont des fichiers YAML à la racine.
+          # les seuls changements sont des fichiers de configuration à la racine.
           # Toute modification d'un fichier de build/package partagé force
           # la compilation complète pour conserver une validation fiable.
           ALL_FILES=$(ls *.yaml | grep -v "secrets.yaml" | jq -R -s -c 'split("\n")[:-1]')
@@ -33,28 +33,24 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED_FILES"
 
-          # If anything outside a root-level YAML changed, a shared package,
-          # component, workflow or other build input may be affected.
-          if echo "$CHANGED_FILES" | grep -qE '(^|/)|(^|)\.(h|hpp|c|cc|cpp|py|json|toml|ini)$'; then
-            if echo "$CHANGED_FILES" | grep -qE '^([^/]+\.yaml)$'; then
-              NON_ROOT=$(echo "$CHANGED_FILES" | grep -vE '^([^/]+\.yaml)$' || true)
-            else
-              NON_ROOT="$CHANGED_FILES"
-            fi
-          else
-            NON_ROOT=""
-          fi
+          # Shared build inputs: package/config YAMLs outside the root,
+          # source files, Python build helpers, dependency files, or this workflow.
+          BUILD_INPUTS=$(echo "$CHANGED_FILES" \
+            | grep -vE '^([^/]+\.yaml)$' \
+            | grep -E '(^|/).*\.(yaml|yml|h|hpp|c|cc|cpp|py|json|toml|ini)$|^requirements\.txt$|^\.github/workflows/esphome-ci\.yaml$' \
+            || true)
 
-          if [ -n "$NON_ROOT" ]; then
+          if [ -n "$BUILD_INPUTS" ]; then
             echo "Shared/build inputs changed; compiling all configurations."
+            echo "$BUILD_INPUTS"
             echo "matrix=$ALL_FILES" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           ROOT_FILES=$(echo "$CHANGED_FILES" | grep -E '^([^/]+\.yaml)$' | grep -v '^secrets\.yaml$' || true)
           MATRIX=$(printf '%s\n' "$ROOT_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           echo "PR configuration matrix: $MATRIX"
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
 
   # Step 2 : Check Coverage
   coverage:

--- a/.github/workflows/esphome-ci.yaml
+++ b/.github/workflows/esphome-ci.yaml
@@ -3,7 +3,7 @@ name: ESPHome Full Build CI
 on: [push, pull_request]
 
 jobs:
-  # Step 1 : List all .yaml files
+  # Step 1 : Determine impacted root configurations
   list-files:
     runs-on: ubuntu-latest
     outputs:
@@ -17,40 +17,29 @@ jobs:
       - name: 📄 Build matrix
         id: set-matrix
         run: |
-          # Liste les .yaml à la racine, exclut secrets.yaml.
-          # Sur une PR, ne compile que les configurations modifiées lorsque
-          # les seuls changements sont des fichiers de configuration à la racine.
-          # Toute modification d'un fichier de build/package partagé force
-          # la compilation complète pour conserver une validation fiable.
-          ALL_FILES=$(ls *.yaml | grep -v "secrets.yaml" | jq -R -s -c 'split("\n")[:-1]')
-
           if [ "${{ github.event_name }}" = "push" ]; then
-            echo "matrix=$ALL_FILES" >> "$GITHUB_OUTPUT"
-            exit 0
+            MATRIX=$(bash ./tools/build_matrix.sh --all | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          else
+            MATRIX=$(bash ./tools/build_matrix.sh \
+              "${{ github.event.pull_request.base.sha }}" \
+              "${{ github.event.pull_request.head.sha }}" \
+              | jq -R -s -c 'split("\n") | map(select(length > 0))')
           fi
-
-          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-
-          # Shared build inputs: package/config YAMLs outside the root,
-          # source files, Python build helpers, dependency files, or this workflow.
-          BUILD_INPUTS=$(echo "$CHANGED_FILES" \
-            | grep -vE '^([^/]+\.yaml)$' \
-            | grep -E '(^|/).*\.(yaml|yml|h|hpp|c|cc|cpp|py|json|toml|ini)$|^requirements\.txt$|^\.github/workflows/esphome-ci\.yaml$' \
-            || true)
-
-          if [ -n "$BUILD_INPUTS" ]; then
-            echo "Shared/build inputs changed; compiling all configurations."
-            echo "$BUILD_INPUTS"
-            echo "matrix=$ALL_FILES" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          ROOT_FILES=$(echo "$CHANGED_FILES" | grep -E '^([^/]+\.yaml)$' | grep -v '^secrets\.yaml$' || true)
-          MATRIX=$(printf '%s\n' "$ROOT_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
-          echo "PR configuration matrix: $MATRIX"
+          echo "ESPHome build matrix: $MATRIX"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+
+  # Step 1.5 : Test repository tooling
+  tools-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 📥 Checkout repository
+        uses: actions/checkout@v7
+
+      - name: 🧪 Install Bats
+        run: sudo apt-get update && sudo apt-get install -y bats
+
+      - name: 🧪 Run tool tests
+        run: bats tests/tools
 
   # Step 2 : Check Coverage
   coverage:
@@ -106,7 +95,7 @@ jobs:
 
   # Step 4 : Compile files
   build:
-    needs: [list-files, check-version]
+    needs: [list-files, check-version, tools-tests]
     if: ${{ needs.list-files.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/esphome-ci.yaml
+++ b/.github/workflows/esphome-ci.yaml
@@ -11,13 +11,50 @@ jobs:
     steps:
       - name: 📥 Checkout repository
         uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
 
       - name: 📄 Build matrix
         id: set-matrix
         run: |
-          # Liste les .yaml à la racine, exclut secrets.yaml
-          FILES=$(ls *.yaml | grep -v "secrets.yaml" | jq -R -s -c 'split("\n")[:-1]')
-          echo "matrix=$FILES" >> "$GITHUB_OUTPUT"
+          # Liste les .yaml à la racine, exclut secrets.yaml.
+          # Sur une PR, ne compile que les configurations modifiées lorsque
+          # les seuls changements sont des fichiers YAML à la racine.
+          # Toute modification d'un fichier de build/package partagé force
+          # la compilation complète pour conserver une validation fiable.
+          ALL_FILES=$(ls *.yaml | grep -v "secrets.yaml" | jq -R -s -c 'split("\n")[:-1]')
+
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "matrix=$ALL_FILES" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED_FILES=$(git diff --name-only "${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }}")
+          echo "Changed files:"
+          echo "$CHANGED_FILES"
+
+          # If anything outside a root-level YAML changed, a shared package,
+          # component, workflow or other build input may be affected.
+          if echo "$CHANGED_FILES" | grep -qE '(^|/)|(^|)\.(h|hpp|c|cc|cpp|py|json|toml|ini)$'; then
+            if echo "$CHANGED_FILES" | grep -qE '^([^/]+\.yaml)$'; then
+              NON_ROOT=$(echo "$CHANGED_FILES" | grep -vE '^([^/]+\.yaml)$' || true)
+            else
+              NON_ROOT="$CHANGED_FILES"
+            fi
+          else
+            NON_ROOT=""
+          fi
+
+          if [ -n "$NON_ROOT" ]; then
+            echo "Shared/build inputs changed; compiling all configurations."
+            echo "matrix=$ALL_FILES" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          ROOT_FILES=$(echo "$CHANGED_FILES" | grep -E '^([^/]+\.yaml)$' | grep -v '^secrets\.yaml$' || true)
+          MATRIX=$(printf '%s\n' "$ROOT_FILES" | jq -R -s -c 'split("\n") | map(select(length > 0))')
+          echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
+          echo "PR configuration matrix: $MATRIX"
 
   # Step 2 : Check Coverage
   coverage:
@@ -60,7 +97,7 @@ jobs:
       - name: 📦 Install dependencies
         run: |
           python -m pip install --upgrade pip
-          sed -i "/esphome/d" requirements.txt 
+          sed -i "/esphome/d" requirements.txt
           pip install -r requirements.txt
 
       - name: 📄 Check Documentation Coverage
@@ -74,6 +111,7 @@ jobs:
   # Step 4 : Compile files
   build:
     needs: [list-files, check-version]
+    if: ${{ needs.list-files.outputs.matrix != '[]' }}
     runs-on: ubuntu-latest
     env:
       CCACHE_DIR: ${{ github.workspace }}/.ccache

--- a/README.md
+++ b/README.md
@@ -18,3 +18,9 @@ This integration enables users to effortlessly monitor and control the router's 
 <img src="docs/images/SolarRouterClosed.png" alt="drawing" style="width:400px;"/>
 <img src="docs/images/SolarRouterInHomeAssistantDashboard.png" alt="drawing" style="width:350px;"/>
 </div>
+
+## Transparency about AI-Assisted Development
+
+The initial development has been preformed from scratch wihtout any AI assistance.
+
+Since version 1.6.7, the development could be assisted by an AI agents, closely coached and supervised by developers. Particular attention is given to the software architecture, code quality, maintainability, and test coverage, with the goal of ensuring a robust and well-engineered codebase.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,11 @@
+# Tool tests
+
+The repository tooling tests use [Bats](https://bats-core.readthedocs.io/) and live under `tests/tools/`.
+
+Run them locally with:
+
+```bash
+bats tests/tools
+```
+
+The tests intentionally build temporary Git repositories so dependency resolution is checked against real Git refs. This framework can be reused by future validation scripts.

--- a/tests/tools/build_matrix.bats
+++ b/tests/tools/build_matrix.bats
@@ -1,0 +1,115 @@
+#!/usr/bin/env bats
+
+setup() {
+  export FIXTURE="$(mktemp -d)"
+  cd "$FIXTURE"
+  git init -q
+  git config user.email test@example.invalid
+  git config user.name "Build Matrix Tests"
+  mkdir -p solar_router
+}
+
+teardown() { rm -rf "$FIXTURE"; }
+
+commit_fixture() {
+  git add .
+  git commit -qm "fixture"
+  git rev-parse HEAD
+}
+
+build_matrix() {
+  bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh" "$1" "$2"
+}
+
+@test "direct root change selects only that root" {
+  printf 'name: a\n' > a.yaml
+  printf 'name: b\n' > b.yaml
+  base=$(commit_fixture)
+  echo '# changed' >> a.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
+}
+
+@test "package change selects all directly dependent roots" {
+  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
+  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > b.yaml
+  printf 'value: 1\n' > solar_router/shared.yaml
+  base=$(commit_fixture)
+  echo 'value: 2' > solar_router/shared.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = $'a.yaml\nb.yaml' ]
+}
+
+@test "transitive includes select the root" {
+  printf 'packages:\n  p:\n    path: solar_router/entry.yaml\n' > a.yaml
+  printf 'value: !include middle.yaml\n' > solar_router/entry.yaml
+  printf 'value: !include leaf.yaml\n' > solar_router/middle.yaml
+  printf 'value: 1\n' > solar_router/leaf.yaml
+  base=$(commit_fixture)
+  echo 'value: 2' > solar_router/leaf.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
+}
+
+@test "multiple changed dependencies produce a sorted union without duplicates" {
+  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
+  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > b.yaml
+  printf 'value: 1\n' > solar_router/shared.yaml
+  base=$(commit_fixture)
+  echo 'value: 2' > solar_router/shared.yaml
+  echo '# direct change' >> a.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = $'a.yaml\nb.yaml' ]
+}
+
+@test "unrelated changes produce an empty matrix" {
+  printf 'name: a\n' > a.yaml
+  printf 'name: b\n' > b.yaml
+  printf 'docs\n' > README.md
+  base=$(commit_fixture)
+  echo 'more docs' >> README.md
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "deleted dependency still selects the previous dependents" {
+  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
+  printf 'value: 1\n' > solar_router/shared.yaml
+  base=$(commit_fixture)
+  rm solar_router/shared.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
+}
+
+@test "new root is selected when added" {
+  printf 'name: a\n' > a.yaml
+  base=$(commit_fixture)
+  printf 'name: b\n' > b.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = "b.yaml" ]
+}
+
+@test "all lists every eligible root and excludes secrets/local files" {
+  printf 'name: a\n' > a.yaml
+  printf 'name: b\n' > b.yaml
+  printf 'secret: x\n' > secrets.yaml
+  printf 'local: x\n' > local_test.yaml
+  commit_fixture >/dev/null
+  run bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh" --all
+  [ "$status" -eq 0 ]
+  [ "$output" = $'a.yaml\nb.yaml' ]
+}

--- a/tests/tools/build_matrix.bats
+++ b/tests/tools/build_matrix.bats
@@ -44,6 +44,17 @@ build_matrix() {
   [ "$output" = $'a.yaml\nb.yaml' ]
 }
 
+@test "include package syntax selects dependent root" {
+  printf 'packages:\n  p: !include solar_router/shared.yaml\n' > a.yaml
+  printf 'value: 1\n' > solar_router/shared.yaml
+  base=$(commit_fixture)
+  echo 'value: 2' > solar_router/shared.yaml
+  head=$(commit_fixture)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
+}
+
 @test "transitive includes select the root" {
   printf 'packages:\n  p:\n    path: solar_router/entry.yaml\n' > a.yaml
   printf 'value: !include middle.yaml\n' > solar_router/entry.yaml
@@ -82,6 +93,15 @@ build_matrix() {
   [ -z "$output" ]
 }
 
+@test "no changes produce an empty matrix" {
+  printf 'name: a\n' > a.yaml
+  base=$(commit_fixture)
+  head=$(git rev-parse HEAD)
+  run build_matrix "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
 @test "deleted dependency still selects the previous dependents" {
   printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
   printf 'value: 1\n' > solar_router/shared.yaml
@@ -91,6 +111,18 @@ build_matrix() {
   run build_matrix "$base" "$head"
   [ "$status" -eq 0 ]
   [ "$output" = "a.yaml" ]
+}
+
+@test "dependency cycles do not loop forever" {
+  printf 'packages:\n  p:\n    path: solar_router/a.yaml\n' > root.yaml
+  printf 'value: !include b.yaml\n' > solar_router/a.yaml
+  printf 'value: !include a.yaml\n' > solar_router/b.yaml
+  base=$(commit_fixture)
+  echo '# changed' >> solar_router/b.yaml
+  head=$(commit_fixture)
+  run timeout 5 bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh" "$base" "$head"
+  [ "$status" -eq 0 ]
+  [ "$output" = "root.yaml" ]
 }
 
 @test "new root is selected when added" {

--- a/tests/tools/build_matrix.bats
+++ b/tests/tools/build_matrix.bats
@@ -134,6 +134,21 @@ build_matrix() {
   [ "$output" = "b.yaml" ]
 }
 
+@test "clean branch compares against main, not only HEAD^" {
+  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
+  printf 'value: 1\n' > solar_router/shared.yaml
+  commit_fixture >/dev/null
+  git branch -M main
+  git checkout -qb feature
+  echo 'value: 2' > solar_router/shared.yaml
+  commit_fixture >/dev/null
+  echo 'more docs' >> README.md
+  commit_fixture >/dev/null
+  run build_matrix
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
+}
+
 @test "uncommitted dependency change selects dependent root" {
   printf 'packages:\n  p:\n    files:\n      - path: solar_router/shared.yaml\n' > a.yaml
   printf 'value: 1\n' > solar_router/shared.yaml

--- a/tests/tools/build_matrix.bats
+++ b/tests/tools/build_matrix.bats
@@ -18,28 +18,28 @@ commit_fixture() {
 }
 
 build_matrix() {
-  bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh" "$1" "$2"
+  bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh"
 }
 
 @test "direct root change selects only that root" {
   printf 'name: a\n' > a.yaml
   printf 'name: b\n' > b.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo '# changed' >> a.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = "a.yaml" ]
 }
 
 @test "package change selects all directly dependent roots" {
-  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
-  printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > b.yaml
+  printf 'packages:\n  p:\n    files:\n      - path: solar_router/shared.yaml\n' > a.yaml
+  printf 'packages:\n  p:\n    files:\n      - path: solar_router/shared.yaml\n' > b.yaml
   printf 'value: 1\n' > solar_router/shared.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo 'value: 2' > solar_router/shared.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = $'a.yaml\nb.yaml' ]
 }
@@ -47,10 +47,10 @@ build_matrix() {
 @test "include package syntax selects dependent root" {
   printf 'packages:\n  p: !include solar_router/shared.yaml\n' > a.yaml
   printf 'value: 1\n' > solar_router/shared.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo 'value: 2' > solar_router/shared.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = "a.yaml" ]
 }
@@ -60,10 +60,10 @@ build_matrix() {
   printf 'value: !include middle.yaml\n' > solar_router/entry.yaml
   printf 'value: !include leaf.yaml\n' > solar_router/middle.yaml
   printf 'value: 1\n' > solar_router/leaf.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo 'value: 2' > solar_router/leaf.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = "a.yaml" ]
 }
@@ -72,11 +72,11 @@ build_matrix() {
   printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
   printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > b.yaml
   printf 'value: 1\n' > solar_router/shared.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo 'value: 2' > solar_router/shared.yaml
   echo '# direct change' >> a.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = $'a.yaml\nb.yaml' ]
 }
@@ -85,19 +85,18 @@ build_matrix() {
   printf 'name: a\n' > a.yaml
   printf 'name: b\n' > b.yaml
   printf 'docs\n' > README.md
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo 'more docs' >> README.md
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
 
 @test "no changes produce an empty matrix" {
   printf 'name: a\n' > a.yaml
-  base=$(commit_fixture)
-  head=$(git rev-parse HEAD)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ -z "$output" ]
 }
@@ -105,10 +104,10 @@ build_matrix() {
 @test "deleted dependency still selects the previous dependents" {
   printf 'packages:\n  p:\n    path: solar_router/shared.yaml\n' > a.yaml
   printf 'value: 1\n' > solar_router/shared.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   rm solar_router/shared.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = "a.yaml" ]
 }
@@ -117,22 +116,42 @@ build_matrix() {
   printf 'packages:\n  p:\n    path: solar_router/a.yaml\n' > root.yaml
   printf 'value: !include b.yaml\n' > solar_router/a.yaml
   printf 'value: !include a.yaml\n' > solar_router/b.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   echo '# changed' >> solar_router/b.yaml
-  head=$(commit_fixture)
-  run timeout 5 bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh" "$base" "$head"
+  commit_fixture >/dev/null
+  run timeout 5 bash "$BATS_TEST_DIRNAME/../../tools/build_matrix.sh"
   [ "$status" -eq 0 ]
   [ "$output" = "root.yaml" ]
 }
 
 @test "new root is selected when added" {
   printf 'name: a\n' > a.yaml
-  base=$(commit_fixture)
+  commit_fixture >/dev/null
   printf 'name: b\n' > b.yaml
-  head=$(commit_fixture)
-  run build_matrix "$base" "$head"
+  commit_fixture >/dev/null
+  run build_matrix
   [ "$status" -eq 0 ]
   [ "$output" = "b.yaml" ]
+}
+
+@test "uncommitted dependency change selects dependent root" {
+  printf 'packages:\n  p:\n    files:\n      - path: solar_router/shared.yaml\n' > a.yaml
+  printf 'value: 1\n' > solar_router/shared.yaml
+  commit_fixture >/dev/null
+  echo 'value: 2' > solar_router/shared.yaml
+  run build_matrix
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
+}
+
+@test "uncommitted root change selects that root" {
+  printf 'name: a\n' > a.yaml
+  printf 'name: b\n' > b.yaml
+  commit_fixture >/dev/null
+  echo '# changed' >> a.yaml
+  run build_matrix
+  [ "$status" -eq 0 ]
+  [ "$output" = "a.yaml" ]
 }
 
 @test "all lists every eligible root and excludes secrets/local files" {

--- a/tests/tools/build_matrix.bats
+++ b/tests/tools/build_matrix.bats
@@ -3,7 +3,7 @@
 setup() {
   export FIXTURE="$(mktemp -d)"
   cd "$FIXTURE"
-  git init -q
+  git init -q -b fixture
   git config user.email test@example.invalid
   git config user.name "Build Matrix Tests"
   mkdir -p solar_router

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -151,6 +151,25 @@ build_from_refs() {
   done
 }
 
+build_from_local() {
+  local base="$1" head="$2" root
+  local -a changed=()
+  declare -A impacted=()
+
+  while IFS= read -r root; do
+    if [[ -n "$root" ]]; then impacted["$root"]=1; fi
+  done < <(build_from_refs "$base" "$head")
+
+  mapfile -t changed < <(local_changes)
+  if ((${#changed[@]})); then
+    while IFS= read -r root; do
+      if [[ -n "$root" ]]; then impacted["$root"]=1; fi
+    done < <(build_from_worktree "${changed[@]}")
+  fi
+
+  for root in "${!impacted[@]}"; do printf '%s\n' "$root"; done | sort
+}
+
 if [[ "${1:-}" == "--all" ]]; then
   [[ $# -eq 1 ]] || usage
   root_files HEAD
@@ -158,20 +177,16 @@ if [[ "${1:-}" == "--all" ]]; then
 fi
 [[ $# -eq 0 ]] || usage
 
-mapfile -t changed < <(local_changes)
-if ((${#changed[@]})); then
-  build_from_worktree "${changed[@]}"
-  exit 0
-fi
-
 if [[ -n "${BUILD_MATRIX_BASE:-}" || -n "${BUILD_MATRIX_HEAD:-}" ]]; then
   [[ -n "${BUILD_MATRIX_BASE:-}" && -n "${BUILD_MATRIX_HEAD:-}" ]] || { echo "BUILD_MATRIX_BASE and BUILD_MATRIX_HEAD must be set together" >&2; exit 2; }
   base="$BUILD_MATRIX_BASE"; head="$BUILD_MATRIX_HEAD"
-else
-  head=HEAD
-  if ! base=$(local_base_ref); then
-    exit 0
-  fi
+  build_from_refs "$base" "$head"
+  exit 0
 fi
 
-build_from_refs "$base" "$head"
+head=HEAD
+if ! base=$(local_base_ref); then
+  exit 0
+fi
+
+build_from_local "$base" "$head"

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -92,6 +92,23 @@ local_changes() {
   { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
 }
 
+local_base_ref() {
+  local ref
+  for ref in origin/main main; do
+    if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+      git merge-base HEAD "$ref"
+      return 0
+    fi
+  done
+
+  if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+    git rev-parse HEAD^
+    return 0
+  fi
+
+  return 1
+}
+
 build_from_worktree() {
   local path root
   local -a changed=("$@")
@@ -152,7 +169,9 @@ if [[ -n "${BUILD_MATRIX_BASE:-}" || -n "${BUILD_MATRIX_HEAD:-}" ]]; then
   base="$BUILD_MATRIX_BASE"; head="$BUILD_MATRIX_HEAD"
 else
   head=HEAD
-  if git rev-parse --verify HEAD^ >/dev/null 2>&1; then base=HEAD^; else exit 0; fi
+  if ! base=$(local_base_ref); then
+    exit 0
+  fi
 fi
 
 build_from_refs "$base" "$head"

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "Usage: $0 --all | <base-ref> <head-ref>" >&2
+  exit 2
+}
+
+repo_file() {
+  local ref="$1" path="$2"
+  if git cat-file -e "${ref}:${path}" 2>/dev/null; then
+    git show --format= --no-ext-diff "${ref}:${path}"
+  fi
+}
+
+root_files() {
+  local ref="$1"
+  git ls-tree -r --name-only "$ref" \
+    | awk -F/ 'NF == 1 && $0 ~ /\.yaml$/ && $0 != "secrets.yaml" && $0 !~ /^local_/ { print }' \
+    | sort
+}
+
+extract_deps() {
+  local ref="$1" source="$2" content dir dep
+  content=$(repo_file "$ref" "$source")
+  dir=$(dirname "$source")
+
+  # ESPHome !include paths are relative to the file containing the tag.
+  while IFS= read -r dep; do
+    dep=${dep#"${dep%%[![:space:]]*}"}
+    dep=${dep%"${dep##*[![:space:]]}"}
+    dep=${dep#"'"}; dep=${dep%"'"}
+    dep=${dep#'"'}; dep=${dep%'"'}
+    [[ "$dep" == *.yaml || "$dep" == *.yml ]] || continue
+    if [[ "$dep" == /* ]]; then
+      dep=${dep#/}
+    else
+      dep="$dir/$dep"
+    fi
+    dep=$(realpath -m --relative-to=. "$dep")
+    [[ "$dep" != ../* ]] || continue
+    printf '%s\n' "$dep"
+  done < <(printf '%s\n' "$content" | sed -nE 's/.*!include[[:space:]]+([^[:space:]#]+).*/\1/p')
+
+  # Package paths are repository-relative, even when declared by a root file.
+  while IFS= read -r dep; do
+    dep=${dep#"${dep%%[![:space:]]*}"}
+    dep=${dep%"${dep##*[![:space:]]}"}
+    dep=${dep#"'"}; dep=${dep%"'"}
+    dep=${dep#'"'}; dep=${dep%'"'}
+    [[ "$dep" == *.yaml || "$dep" == *.yml ]] || continue
+    printf '%s\n' "$dep"
+  done < <(printf '%s\n' "$content" | sed -nE 's/^[[:space:]]*path:[[:space:]]*([^[:space:]#]+).*/\1/p')
+}
+
+impacted_by_ref() {
+  local ref="$1" root="$2" changed="$3"
+  declare -A seen=()
+  local queue=("$root") current dep
+
+  while ((${#queue[@]})); do
+    current=${queue[0]}
+    queue=("${queue[@]:1}")
+    [[ -n "${seen[$current]+x}" ]] && continue
+    seen["$current"]=1
+
+    [[ "$current" == "$changed" ]] && return 0
+
+    while IFS= read -r dep; do
+      [[ -n "$dep" ]] && [[ -z "${seen[$dep]+x}" ]] && queue+=("$dep")
+    done < <(extract_deps "$ref" "$current")
+  done
+
+  return 1
+}
+
+if [[ "${1:-}" == "--all" ]]; then
+  root_files HEAD
+  exit 0
+fi
+
+[[ $# -eq 2 ]] || usage
+base=$1
+head=$2
+
+mapfile -t changed < <(git diff --name-only "$base...$head")
+mapfile -t roots < <(root_files "$head")
+
+for root in "${roots[@]}"; do
+  hit=0
+  for path in "${changed[@]}"; do
+    if [[ "$path" == "$root" ]] || \
+       impacted_by_ref "$head" "$root" "$path" || \
+       impacted_by_ref "$base" "$root" "$path"; then
+      hit=1
+      break
+    fi
+  done
+  if (( hit )); then
+    printf '%s\n' "$root"
+  fi
+done

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -94,7 +94,7 @@ local_changes() {
 
 local_base_ref() {
   local ref
-  for ref in origin/main main; do
+  for ref in main origin/main; do
     if git rev-parse --verify "$ref" >/dev/null 2>&1; then
       git merge-base HEAD "$ref"
       return 0

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -128,36 +128,18 @@ local_changes() {
   } | sort -u
 }
 
-build_from_changes() {
-  local mode="$1"
-  shift
+build_from_worktree() {
   local root path hit
   local -a changed=("$@")
   local -a roots=()
-
-  if [[ "$mode" == "worktree" ]]; then
-    mapfile -t roots < <(root_files_worktree)
-  else
-    mapfile -t roots < <(root_files "$1")
-  fi
+  mapfile -t roots < <(root_files_worktree)
 
   for root in "${roots[@]}"; do
     hit=0
     for path in "${changed[@]}"; do
-      if [[ "$path" == "$root" ]]; then
+      if [[ "$path" == "$root" ]] || impacted_by_worktree "$root" "$path"; then
         hit=1
         break
-      fi
-      if [[ "$mode" == "worktree" ]]; then
-        if impacted_by_worktree "$root" "$path"; then
-          hit=1
-          break
-        fi
-      else
-        if impacted_by_ref "$1" "$root" "$path" || impacted_by_ref "$2" "$root" "$path"; then
-          hit=1
-          break
-        fi
       fi
     done
     if (( hit )); then
@@ -176,12 +158,26 @@ fi
 
 mapfile -t changed < <(local_changes)
 if ((${#changed[@]})); then
-  build_from_changes worktree "${changed[@]}"
+  build_from_worktree "${changed[@]}"
   exit 0
 fi
 
-base="${BUILD_MATRIX_BASE:-HEAD^}"
-head="${BUILD_MATRIX_HEAD:-HEAD}"
+if [[ -n "${BUILD_MATRIX_BASE:-}" || -n "${BUILD_MATRIX_HEAD:-}" ]]; then
+  [[ -n "${BUILD_MATRIX_BASE:-}" && -n "${BUILD_MATRIX_HEAD:-}" ]] || {
+    echo "BUILD_MATRIX_BASE and BUILD_MATRIX_HEAD must be set together" >&2
+    exit 2
+  }
+  base="$BUILD_MATRIX_BASE"
+  head="$BUILD_MATRIX_HEAD"
+else
+  head=HEAD
+  if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+    base=HEAD^
+  else
+    exit 0
+  fi
+fi
+
 mapfile -t changed < <(git diff --name-only "$base...$head")
 mapfile -t roots < <(root_files "$head")
 

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -98,7 +98,9 @@ build_from_worktree() {
   declare -A impacted=()
   build_graph worktree
   for path in "${changed[@]}"; do
-    while IFS= read -r root; do [[ -n "$root" ]] && impacted["$root"]=1; done < <(impacted_roots_from_graph "$path")
+    while IFS= read -r root; do
+      if [[ -n "$root" ]]; then impacted["$root"]=1; fi
+    done < <(impacted_roots_from_graph "$path")
   done
   for path in "${!impacted[@]}"; do printf '%s\n' "$path"; done | sort
 }
@@ -112,16 +114,24 @@ build_from_refs() {
 
   build_graph ref "$head"
   for path in "${changed[@]}"; do
-    while IFS= read -r root; do [[ -n "$root" ]] && impacted["$root"]=1; done < <(impacted_roots_from_graph "$path")
+    while IFS= read -r root; do
+      if [[ -n "$root" ]]; then impacted["$root"]=1; fi
+    done < <(impacted_roots_from_graph "$path")
   done
 
   build_graph ref "$base"
   for path in "${changed[@]}"; do
-    while IFS= read -r root; do [[ -n "$root" ]] && impacted["$root"]=1; done < <(impacted_roots_from_graph "$path")
+    while IFS= read -r root; do
+      if [[ -n "$root" ]]; then impacted["$root"]=1; fi
+    done < <(impacted_roots_from_graph "$path")
   done
 
   mapfile -t roots < <(root_files "$head")
-  for root in "${roots[@]}"; do [[ -n "${impacted[$root]+x}" ]] && printf '%s\n' "$root"; done
+  for root in "${roots[@]}"; do
+    if [[ -n "${impacted[$root]+x}" ]]; then
+      printf '%s\n' "$root"
+    fi
+  done
 }
 
 if [[ "${1:-}" == "--all" ]]; then

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 usage() {
-  echo "Usage: $0 --all | <base-ref> <head-ref>" >&2
+  echo "Usage: $0 [--all]" >&2
   exit 2
 }
 
@@ -13,6 +13,15 @@ repo_file() {
   fi
 }
 
+worktree_file() {
+  local path="$1"
+  if [[ -f "$path" ]]; then
+    cat "$path"
+  elif git cat-file -e "HEAD:${path}" 2>/dev/null; then
+    git show --format= --no-ext-diff "HEAD:${path}"
+  fi
+}
+
 root_files() {
   local ref="$1"
   git ls-tree -r --name-only "$ref" \
@@ -20,9 +29,14 @@ root_files() {
     | sort
 }
 
-extract_deps() {
-  local ref="$1" source="$2" content dir dep
-  content=$(repo_file "$ref" "$source")
+root_files_worktree() {
+  find . -maxdepth 1 -type f -name '*.yaml' -printf '%f\n' \
+    | awk '$0 != "secrets.yaml" && $0 !~ /^local_/' \
+    | sort
+}
+
+extract_deps_from_content() {
+  local source="$1" content="$2" dir dep
   dir=$(dirname "$source")
 
   # ESPHome !include paths are relative to the file containing the tag.
@@ -55,6 +69,16 @@ extract_deps() {
   done < <(printf '%s\n' "$content" | sed -nE 's/^[[:space:]]*(-[[:space:]]*)?path:[[:space:]]*([^[:space:]#]+).*/\2/p')
 }
 
+extract_deps() {
+  local ref="$1" source="$2"
+  extract_deps_from_content "$source" "$(repo_file "$ref" "$source")"
+}
+
+extract_deps_worktree() {
+  local source="$1"
+  extract_deps_from_content "$source" "$(worktree_file "$source")"
+}
+
 impacted_by_ref() {
   local ref="$1" root="$2" changed="$3"
   declare -A seen=()
@@ -76,15 +100,88 @@ impacted_by_ref() {
   return 1
 }
 
+impacted_by_worktree() {
+  local root="$1" changed="$2"
+  declare -A seen=()
+  local queue=("$root") current dep
+
+  while ((${#queue[@]})); do
+    current=${queue[0]}
+    queue=("${queue[@]:1}")
+    [[ -n "${seen[$current]+x}" ]] && continue
+    seen["$current"]=1
+
+    [[ "$current" == "$changed" ]] && return 0
+
+    while IFS= read -r dep; do
+      [[ -n "$dep" ]] && [[ -z "${seen[$dep]+x}" ]] && queue+=("$dep")
+    done < <(extract_deps_worktree "$current")
+  done
+
+  return 1
+}
+
+local_changes() {
+  {
+    git diff --name-only HEAD
+    git ls-files --others --exclude-standard
+  } | sort -u
+}
+
+build_from_changes() {
+  local mode="$1"
+  shift
+  local root path hit
+  local -a changed=("$@")
+  local -a roots=()
+
+  if [[ "$mode" == "worktree" ]]; then
+    mapfile -t roots < <(root_files_worktree)
+  else
+    mapfile -t roots < <(root_files "$1")
+  fi
+
+  for root in "${roots[@]}"; do
+    hit=0
+    for path in "${changed[@]}"; do
+      if [[ "$path" == "$root" ]]; then
+        hit=1
+        break
+      fi
+      if [[ "$mode" == "worktree" ]]; then
+        if impacted_by_worktree "$root" "$path"; then
+          hit=1
+          break
+        fi
+      else
+        if impacted_by_ref "$1" "$root" "$path" || impacted_by_ref "$2" "$root" "$path"; then
+          hit=1
+          break
+        fi
+      fi
+    done
+    if (( hit )); then
+      printf '%s\n' "$root"
+    fi
+  done
+}
+
 if [[ "${1:-}" == "--all" ]]; then
+  [[ $# -eq 1 ]] || usage
   root_files HEAD
   exit 0
 fi
 
-[[ $# -eq 2 ]] || usage
-base=$1
-head=$2
+[[ $# -eq 0 ]] || usage
 
+mapfile -t changed < <(local_changes)
+if ((${#changed[@]})); then
+  build_from_changes worktree "${changed[@]}"
+  exit 0
+fi
+
+base="${BUILD_MATRIX_BASE:-HEAD^}"
+head="${BUILD_MATRIX_HEAD:-HEAD}"
 mapfile -t changed < <(git diff --name-only "$base...$head")
 mapfile -t roots < <(root_files "$head")
 

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -106,7 +106,7 @@ local_base_ref() {
     return 0
   fi
 
-  return 1
+  git rev-parse HEAD
 }
 
 build_from_worktree() {

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -24,128 +24,104 @@ worktree_file() {
 
 root_files() {
   local ref="$1"
-  git ls-tree -r --name-only "$ref" \
-    | awk -F/ 'NF == 1 && $0 ~ /\.yaml$/ && $0 != "secrets.yaml" && $0 !~ /^local_/ { print }' \
-    | sort
+  git ls-tree -r --name-only "$ref" | awk -F/ 'NF == 1 && $0 ~ /\.yaml$/ && $0 != "secrets.yaml" && $0 !~ /^local_/ { print }' | sort
 }
 
 root_files_worktree() {
-  find . -maxdepth 1 -type f -name '*.yaml' -printf '%f\n' \
-    | awk '$0 != "secrets.yaml" && $0 !~ /^local_/' \
-    | sort
+  find . -maxdepth 1 -type f -name '*.yaml' -printf '%f\n' | awk '$0 != "secrets.yaml" && $0 !~ /^local_/' | sort
 }
 
 extract_deps_from_content() {
   local source="$1" content="$2" dir dep
   dir=$(dirname "$source")
 
-  # ESPHome !include paths are relative to the file containing the tag.
   while IFS= read -r dep; do
-    dep=${dep#"${dep%%[![:space:]]*}"}
-    dep=${dep%"${dep##*[![:space:]]}"}
-    dep=${dep#"'"}; dep=${dep%"'"}
-    dep=${dep#'"'}; dep=${dep%'"'}
+    dep=${dep#"${dep%%[![:space:]]*}"}; dep=${dep%"${dep##*[![:space:]]}"}
+    dep=${dep#"'"}; dep=${dep%"'"}; dep=${dep#'"'}; dep=${dep%'"'}
     [[ "$dep" == *.yaml || "$dep" == *.yml ]] || continue
-    if [[ "$dep" == /* ]]; then
-      dep=${dep#/}
-    else
-      dep="$dir/$dep"
-    fi
+    if [[ "$dep" == /* ]]; then dep=${dep#/}; else dep="$dir/$dep"; fi
     dep=$(realpath -m --relative-to=. "$dep")
     [[ "$dep" != ../* ]] || continue
     printf '%s\n' "$dep"
   done < <(printf '%s\n' "$content" | sed -nE 's/.*!include[[:space:]]+([^[:space:]#]+).*/\1/p')
 
-  # Package paths are repository-relative, including the common YAML list form:
-  #   files:
-  #     - path: solar_router/foo.yaml
   while IFS= read -r dep; do
-    dep=${dep#"${dep%%[![:space:]]*}"}
-    dep=${dep%"${dep##*[![:space:]]}"}
-    dep=${dep#"'"}; dep=${dep%"'"}
-    dep=${dep#'"'}; dep=${dep%'"'}
+    dep=${dep#"${dep%%[![:space:]]*}"}; dep=${dep%"${dep##*[![:space:]]}"}
+    dep=${dep#"'"}; dep=${dep%"'"}; dep=${dep#'"'}; dep=${dep%'"'}
     [[ "$dep" == *.yaml || "$dep" == *.yml ]] || continue
     printf '%s\n' "$dep"
   done < <(printf '%s\n' "$content" | sed -nE 's/^[[:space:]]*(-[[:space:]]*)?path:[[:space:]]*([^[:space:]#]+).*/\2/p')
 }
 
-extract_deps() {
-  local ref="$1" source="$2"
-  extract_deps_from_content "$source" "$(repo_file "$ref" "$source")"
-}
+build_graph() {
+  local mode="$1" ref="${2:-}" file dep content
+  local -a queue=()
+  declare -A visited=()
+  declare -gA reverse_deps=()
 
-extract_deps_worktree() {
-  local source="$1"
-  extract_deps_from_content "$source" "$(worktree_file "$source")"
-}
-
-impacted_by_ref() {
-  local ref="$1" root="$2" changed="$3"
-  declare -A seen=()
-  local queue=("$root") current dep
+  if [[ "$mode" == worktree ]]; then mapfile -t queue < <(root_files_worktree); else mapfile -t queue < <(root_files "$ref"); fi
 
   while ((${#queue[@]})); do
-    current=${queue[0]}
-    queue=("${queue[@]:1}")
-    [[ -n "${seen[$current]+x}" ]] && continue
-    seen["$current"]=1
-
-    [[ "$current" == "$changed" ]] && return 0
-
+    file=${queue[0]}; queue=("${queue[@]:1}")
+    [[ -n "${visited[$file]+x}" ]] && continue
+    visited["$file"]=1
+    if [[ "$mode" == worktree ]]; then content=$(worktree_file "$file"); else content=$(repo_file "$ref" "$file"); fi
     while IFS= read -r dep; do
-      [[ -n "$dep" ]] && [[ -z "${seen[$dep]+x}" ]] && queue+=("$dep")
-    done < <(extract_deps "$ref" "$current")
+      [[ -n "$dep" ]] || continue
+      reverse_deps["$dep"]+=" $file"
+      [[ -n "${visited[$dep]+x}" ]] || queue+=("$dep")
+    done < <(extract_deps_from_content "$file" "$content")
   done
-
-  return 1
 }
 
-impacted_by_worktree() {
-  local root="$1" changed="$2"
-  declare -A seen=()
-  local queue=("$root") current dep
-
+impacted_roots_from_graph() {
+  local current root parent
+  local -a queue=("$@")
+  declare -A seen=() roots_set=()
   while ((${#queue[@]})); do
-    current=${queue[0]}
-    queue=("${queue[@]:1}")
+    current=${queue[0]}; queue=("${queue[@]:1}")
     [[ -n "${seen[$current]+x}" ]] && continue
     seen["$current"]=1
-
-    [[ "$current" == "$changed" ]] && return 0
-
-    while IFS= read -r dep; do
-      [[ -n "$dep" ]] && [[ -z "${seen[$dep]+x}" ]] && queue+=("$dep")
-    done < <(extract_deps_worktree "$current")
+    if [[ "$current" == *.yaml && "$current" != */* && "$current" != "secrets.yaml" && "$current" != local_* ]]; then roots_set["$current"]=1; fi
+    for parent in ${reverse_deps[$current]-}; do [[ -n "${seen[$parent]+x}" ]] || queue+=("$parent"); done
   done
-
-  return 1
+  for root in "${!roots_set[@]}"; do printf '%s\n' "$root"; done | sort
 }
 
 local_changes() {
-  {
-    git diff --name-only HEAD
-    git ls-files --others --exclude-standard
-  } | sort -u
+  { git diff --name-only HEAD; git ls-files --others --exclude-standard; } | sort -u
 }
 
 build_from_worktree() {
-  local root path hit
+  local path root
   local -a changed=("$@")
-  local -a roots=()
-  mapfile -t roots < <(root_files_worktree)
-
-  for root in "${roots[@]}"; do
-    hit=0
-    for path in "${changed[@]}"; do
-      if [[ "$path" == "$root" ]] || impacted_by_worktree "$root" "$path"; then
-        hit=1
-        break
-      fi
-    done
-    if (( hit )); then
-      printf '%s\n' "$root"
-    fi
+  declare -A impacted=()
+  build_graph worktree
+  for path in "${changed[@]}"; do
+    while IFS= read -r root; do [[ -n "$root" ]] && impacted["$root"]=1; done < <(impacted_roots_from_graph "$path")
   done
+  for path in "${!impacted[@]}"; do printf '%s\n' "$path"; done | sort
+}
+
+build_from_refs() {
+  local base="$1" head="$2" path root
+  local -a changed=()
+  declare -A impacted=()
+  mapfile -t changed < <(git diff --name-only "$base...$head")
+  ((${#changed[@]})) || return 0
+
+  build_graph ref "$head"
+  for path in "${changed[@]}"; do
+    while IFS= read -r root; do [[ -n "$root" ]] && impacted["$root"]=1; done < <(impacted_roots_from_graph "$path")
+  done
+
+  build_graph ref "$base"
+  for path in "${changed[@]}"; do
+    while IFS= read -r root; do [[ -n "$root" ]] && impacted["$root"]=1; done < <(impacted_roots_from_graph "$path")
+  done
+
+  mapfile -t roots < <(root_files "$head")
+  for root in "${roots[@]}"; do [[ -n "${impacted[$root]+x}" ]] && printf '%s\n' "$root"; done
 }
 
 if [[ "${1:-}" == "--all" ]]; then
@@ -153,7 +129,6 @@ if [[ "${1:-}" == "--all" ]]; then
   root_files HEAD
   exit 0
 fi
-
 [[ $# -eq 0 ]] || usage
 
 mapfile -t changed < <(local_changes)
@@ -163,35 +138,11 @@ if ((${#changed[@]})); then
 fi
 
 if [[ -n "${BUILD_MATRIX_BASE:-}" || -n "${BUILD_MATRIX_HEAD:-}" ]]; then
-  [[ -n "${BUILD_MATRIX_BASE:-}" && -n "${BUILD_MATRIX_HEAD:-}" ]] || {
-    echo "BUILD_MATRIX_BASE and BUILD_MATRIX_HEAD must be set together" >&2
-    exit 2
-  }
-  base="$BUILD_MATRIX_BASE"
-  head="$BUILD_MATRIX_HEAD"
+  [[ -n "${BUILD_MATRIX_BASE:-}" && -n "${BUILD_MATRIX_HEAD:-}" ]] || { echo "BUILD_MATRIX_BASE and BUILD_MATRIX_HEAD must be set together" >&2; exit 2; }
+  base="$BUILD_MATRIX_BASE"; head="$BUILD_MATRIX_HEAD"
 else
   head=HEAD
-  if git rev-parse --verify HEAD^ >/dev/null 2>&1; then
-    base=HEAD^
-  else
-    exit 0
-  fi
+  if git rev-parse --verify HEAD^ >/dev/null 2>&1; then base=HEAD^; else exit 0; fi
 fi
 
-mapfile -t changed < <(git diff --name-only "$base...$head")
-mapfile -t roots < <(root_files "$head")
-
-for root in "${roots[@]}"; do
-  hit=0
-  for path in "${changed[@]}"; do
-    if [[ "$path" == "$root" ]] || \
-       impacted_by_ref "$head" "$root" "$path" || \
-       impacted_by_ref "$base" "$root" "$path"; then
-      hit=1
-      break
-    fi
-  done
-  if (( hit )); then
-    printf '%s\n' "$root"
-  fi
-done
+build_from_refs "$base" "$head"

--- a/tools/build_matrix.sh
+++ b/tools/build_matrix.sh
@@ -42,7 +42,9 @@ extract_deps() {
     printf '%s\n' "$dep"
   done < <(printf '%s\n' "$content" | sed -nE 's/.*!include[[:space:]]+([^[:space:]#]+).*/\1/p')
 
-  # Package paths are repository-relative, even when declared by a root file.
+  # Package paths are repository-relative, including the common YAML list form:
+  #   files:
+  #     - path: solar_router/foo.yaml
   while IFS= read -r dep; do
     dep=${dep#"${dep%%[![:space:]]*}"}
     dep=${dep%"${dep##*[![:space:]]}"}
@@ -50,7 +52,7 @@ extract_deps() {
     dep=${dep#'"'}; dep=${dep%'"'}
     [[ "$dep" == *.yaml || "$dep" == *.yml ]] || continue
     printf '%s\n' "$dep"
-  done < <(printf '%s\n' "$content" | sed -nE 's/^[[:space:]]*path:[[:space:]]*([^[:space:]#]+).*/\1/p')
+  done < <(printf '%s\n' "$content" | sed -nE 's/^[[:space:]]*(-[[:space:]]*)?path:[[:space:]]*([^[:space:]#]+).*/\2/p')
 }
 
 impacted_by_ref() {

--- a/tools/compile_all_local_yaml.sh
+++ b/tools/compile_all_local_yaml.sh
@@ -1,17 +1,26 @@
-for iloop in $(ls *.yaml | grep -v secrets | grep -v local_) ; do
-   echo
-   echo "#########################################"
-   echo Converting $iloop to local_$iloop
-   python ./tools/convert_to_local_source.py $iloop || exit 1
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+mapfile -t configs < <(cd "$PROJECT_ROOT" && bash ./tools/build_matrix.sh --all)
+
+for iloop in "${configs[@]}"; do
+  echo
+  echo "#########################################"
+  echo "Converting $iloop to local_$iloop"
+  python "$PROJECT_ROOT/tools/convert_to_local_source.py" "$iloop" || exit 1
 done
-for iloop in $(ls local_*.yaml); do
-   filename=$(basename $iloop)
-   echo
-   echo Verifying $iloop
-   esphome config $iloop || exit 1
+
+shopt -s nullglob
+local_files=(local_*.yaml)
+for iloop in "${local_files[@]}"; do
+  echo
+  echo "Verifying $iloop"
+  esphome config "$iloop" || exit 1
 done
-for iloop in $(ls local_*.yaml); do
-   echo
-   echo Compiling $iloop
-   esphome compile $iloop || exit 1
+for iloop in "${local_files[@]}"; do
+  echo
+  echo "Compiling $iloop"
+  esphome compile "$iloop" || exit 1
 done

--- a/tools/compile_locally_updated_yaml.sh
+++ b/tools/compile_locally_updated_yaml.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PROJECT_ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+rm -f ${PROJECT_ROOT}/local_*.yaml
+
+mapfile -t configs < <(cd "$PROJECT_ROOT" && bash ./tools/build_matrix.sh ${1:-})
+
+for iloop in "${configs[@]}"; do
+  echo
+  echo "#########################################"
+  echo "Converting $iloop to local_$iloop"
+  python "$PROJECT_ROOT/tools/convert_to_local_source.py" "$iloop" || exit 1
+done
+
+shopt -s nullglob
+local_files=(local_*.yaml)
+for iloop in "${local_files[@]}"; do
+  echo
+  echo "Verifying $iloop"
+  esphome config "$iloop" || exit 1
+done
+for iloop in "${local_files[@]}"; do
+  echo
+  echo "Compiling $iloop"
+  esphome compile "$iloop" || exit 1
+done


### PR DESCRIPTION
## Summary

Replace the CI-side heuristic for selective ESPHome builds with a reusable dependency-aware build matrix tool.

### Changes
- add `tools/build_matrix.sh` to resolve impacted root `*.yaml` configurations from Git changes;
- follow both ESPHome `!include` dependencies and package `path:` references recursively;
- inspect both base and head trees so deleted/changed dependencies still select their previous dependents;
- keep `--all` for full local builds and reuse it from `tools/compile_all_local_yaml.sh`;
- add Bats tests covering direct, shared, transitive, added/deleted and unrelated changes;
- add a dedicated CI job for the reusable tool test framework.

This keeps the selective-build logic out of the workflow and provides the test foundation for future validation tools such as `check_module_version.sh`.