### PR TITLE
docs(module_version): document the version each package publishes

### DIFF
--- a/docs/en/module_version.md
+++ b/docs/en/module_version.md
@@ -1,0 +1,69 @@
+# Module versions
+
+Every package of the solar router publishes its own version to Home Assistant, so a device says
+which modules it is built from and which version of each one it runs.
+
+A solar router is assembled from packages, and once compiled they leave no trace of that assembly:
+two routers with very different capabilities look alike from Home Assistant. These entities close
+that gap.
+
+## Where to find them
+
+They are **diagnostic** entities, so Home Assistant groups them in the *Diagnostic* section of the
+device page. Each one is named after the package file it comes from, and its state is the version:
+
+| Entity                                      | State   |
+| ------------------------------------------- | ------- |
+| `sensor.solarrouter_common`                 | `1.1.1` |
+| `sensor.solarrouter_power_meter_fronius`    | `1.6.3` |
+| `sensor.solarrouter_regulator_triac`        | `1.6.3` |
+| `sensor.solarrouter_engine_1dimmer`         | `1.6.6` |
+
+The list you see *is* the composition of your router. A package that is not loaded publishes
+nothing, so the regulator, the power meter and the engine can all be told apart at a glance — which
+matters most for the regulators, since `regulator_triac`, `regulator_solid_state_relay` and
+`regulator_mecanical_relay` publish no other entity at all.
+
+## Reading the versions
+
+!!! note "Different versions across modules is normal"
+    A release only raises the version of the modules it actually changed, so a healthy router shows
+    a spread of versions — `common` may sit at `1.1.1` while `temperature_fan_control` is at
+    `1.6.7`, both from the same release.
+
+    It follows that the highest version on a device is a **lower bound** on the release it was
+    built from, not the release itself. A router built at `v1.6.7` whose packages were untouched by
+    that release will show nothing above `1.6.6`.
+
+To check whether a module is behind, compare it with the same file in the
+[repository](https://github.com/hacf-fr/Solar-Router-for-ESPHome/tree/main/solar_router) rather than
+with the release number.
+
+## When they are published
+
+The value is sent **once, about ten seconds after the device boots**, and then never again — it
+cannot change while the device is running. Two consequences worth knowing:
+
+* right after a restart the entities are briefly `unknown`, which is expected;
+* the value you see is the one compiled into the firmware, not something read live. Updating your
+  packages requires recompiling and uploading before the versions change.
+
+## Packages loaded more than once
+
+`regulator_mecanical_relay` and `scheduler_forced_run` can be loaded several times, so their entity
+name carries their unique id. With three mechanical relays you get
+`regulator_mecanical_relay_1`, `_2` and `_3`; with the default scheduler you get
+`scheduler_forced_run_Forced`.
+
+!!! warning "One module is invisible"
+    `power_meter_home_assistant` overrides the sensors of `power_meter_common`, and that override
+    also replaces the common's version entity. On a router using the Home Assistant power meter,
+    `power_meter_common` therefore publishes no version even though it is loaded. Its absence tells
+    you nothing.
+
+## Turning them off
+
+These entities are harmless — they hold one short string and never update — but they can be
+disabled in Home Assistant like any other entity if you would rather not see them. Doing so hides
+your router's composition from anything that reads it, so keep them on if you may ever ask for
+support.

--- a/docs/fr/module_version.md
+++ b/docs/fr/module_version.md
@@ -1,0 +1,72 @@
+# Versions des modules
+
+Chaque package du routeur solaire publie sa propre version dans Home Assistant : un appareil indique
+ainsi de quels modules il est composé, et dans quelle version il utilise chacun d'eux.
+
+Un routeur solaire est assemblé à partir de packages qui, une fois compilés, ne laissent aucune
+trace de cet assemblage : deux routeurs aux capacités très différentes se ressemblent vus depuis
+Home Assistant. Ces entités comblent ce manque.
+
+## Où les trouver
+
+Ce sont des entités de **diagnostic**, que Home Assistant regroupe donc dans la section
+*Diagnostic* de la page de l'appareil. Chacune porte le nom du fichier de package dont elle provient,
+et son état est la version :
+
+| Entité                                      | État    |
+| ------------------------------------------- | ------- |
+| `sensor.solarrouter_common`                 | `1.1.1` |
+| `sensor.solarrouter_power_meter_fronius`    | `1.6.3` |
+| `sensor.solarrouter_regulator_triac`        | `1.6.3` |
+| `sensor.solarrouter_engine_1dimmer`         | `1.6.6` |
+
+La liste que vous voyez **est** la composition de votre routeur. Un package non chargé ne publie
+rien : le régulateur, le compteur de puissance et le moteur se distinguent donc d'un coup d'œil. Cela
+compte surtout pour les régulateurs, car `regulator_triac`, `regulator_solid_state_relay` et
+`regulator_mecanical_relay` ne publient aucune autre entité.
+
+## Lire les versions
+
+!!! note "Des versions différentes d'un module à l'autre, c'est normal"
+    Une publication n'incrémente que la version des modules réellement modifiés. Un routeur en bonne
+    santé affiche donc des versions disparates : `common` peut rester en `1.1.1` alors que
+    `temperature_fan_control` est en `1.6.7`, tous deux issus de la même publication.
+
+    Il en découle que la version la plus élevée d'un appareil est une **borne inférieure** de la
+    publication à partir de laquelle il a été construit, et non cette publication. Un routeur
+    construit en `v1.6.7` dont aucun package n'a été touché par cette version n'affichera rien
+    au-dessus de `1.6.6`.
+
+Pour savoir si un module est en retard, comparez-le au même fichier dans le
+[dépôt](https://github.com/hacf-fr/Solar-Router-for-ESPHome/tree/main/solar_router) plutôt qu'au
+numéro de publication.
+
+## Quand elles sont publiées
+
+La valeur est envoyée **une seule fois, environ dix secondes après le démarrage** de l'appareil, puis
+plus jamais — elle ne peut pas changer pendant que l'appareil fonctionne. Deux conséquences à
+connaître :
+
+* juste après un redémarrage, les entités sont brièvement à `unknown`, c'est attendu ;
+* la valeur affichée est celle compilée dans le firmware, elle n'est pas lue en direct. Mettre à jour
+  vos packages suppose de recompiler et de téléverser avant que les versions ne changent.
+
+## Packages chargés plusieurs fois
+
+`regulator_mecanical_relay` et `scheduler_forced_run` peuvent être chargés plusieurs fois : le nom de
+leur entité porte donc leur identifiant unique. Avec trois relais mécaniques vous obtenez
+`regulator_mecanical_relay_1`, `_2` et `_3` ; avec le planificateur par défaut, vous obtenez
+`scheduler_forced_run_Forced`.
+
+!!! warning "Un module reste invisible"
+    `power_meter_home_assistant` surcharge les capteurs de `power_meter_common`, et cette surcharge
+    remplace aussi l'entité de version du common. Sur un routeur utilisant le compteur de puissance
+    Home Assistant, `power_meter_common` ne publie donc aucune version bien qu'il soit chargé. Son
+    absence ne vous apprend rien.
+
+## Les désactiver
+
+Ces entités sont sans conséquence — elles contiennent une courte chaîne de caractères et ne se
+mettent jamais à jour — mais elles peuvent être désactivées dans Home Assistant comme n'importe
+quelle autre entité si vous préférez ne pas les voir. Cela masque la composition de votre routeur à
+tout ce qui la lit : gardez-les actives si vous pouvez avoir besoin d'assistance un jour.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Home Assistant:
               - Recorder configuration: recorder_configuration.md
               - Debug sensors: debug_sensors.md
+              - Module versions: module_version.md
       - About:
               - ChangeLog: changelog.md
               - License: license.md
@@ -109,6 +110,7 @@ plugins:
                             Home: Accueil
                             License: Licence
                             Mecanical relay: Relais mécanique
+                            Module versions: Versions des modules
                             ON/OFF regulation: Regulation tout ou rien
                             Overview: Aperçu
                             Progressive regulation: Régulation progressive


### PR DESCRIPTION
The version text_sensors shipped in #169 without a word of documentation, so the entities appear on every device with nothing explaining what they are or how to read them.

The page covers what the entities are, where Home Assistant files them, and the three things that surprise people:

- versions differ between modules and that is correct, since a release only raises the ones it changed. The highest version on a device is a lower bound on the release it was built from, never the release, so the page says to compare a module against the repository rather than against the release number.
- the value is published once, about ten seconds after boot, and never again — hence a brief `unknown` after every restart, and a value that reflects the compiled firmware rather than anything live.
- `power_meter_common` publishes nothing on a router using the Home Assistant power meter, whose `<<:` merge replaces the common's `text_sensor:` along with its sensors. Its absence means nothing.

Multi-instance naming is documented too, since `_1`/`_2`/`_3` and `scheduler_forced_run_Forced` are otherwise puzzling.

Verified with `mkdocs build --strict` (exit 0, both languages built, the French navigation entry translated), plus the documentation, build and module version coverage checks.